### PR TITLE
[neutron] add ntp server configuration to dhcp-agent config

### DIFF
--- a/openstack/neutron/ci/test-values.yaml
+++ b/openstack/neutron/ci/test-values.yaml
@@ -104,6 +104,7 @@ interconnection:
 
 ml2_mechanismdrivers: myDriver
 dns_forwarders: myDNS
+ntp_servers: 192.0.2.123, 192.0.2.222
 dns_local_domain: myDNSLocal
 global.nova_metadata_secret: topSecret
 dns_ml2_extension: myDNS

--- a/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
+++ b/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
@@ -8,6 +8,9 @@ force_metadata=True
 enable_isolated_metadata=True
 metadata_proxy_socket = /run/metadata_proxy/metadata_proxy
 dnsmasq_dns_servers = {{required "A valid .Values.dns_forwarders required!" .Values.dns_forwarders}}
+{{- if .Values.ntp_servers }}
+dnsmasq_ntp_servers = {{.Values.ntp_servers}}
+{{- end }}
 dhcp_domain = {{required "A valid .Values.dns_local_domain required!" .Values.dns_local_domain}}
 dns_domain = {{required "A valid .Values.dns_local_domain required!" .Values.dns_local_domain}}
 num_sync_threads = {{.Values.agent.dhcp.num_sync_threads | default 4 }}


### PR DESCRIPTION
This adds the ability to configure the default ntp-servers via the agent config file from our values.

This is in preparation of moving the option from the dnsmasq config file to the agent and dynamically setting the commandline argument on dnsmasq.

A dhcp option present in the config file will take precedence over the commandline so we always have to configure them this way.

This requires a custom version of the dhcp-agent.