### PR TITLE
feat(netapp-credential-rotator): update CRD printer columns

### DIFF
--- a/openstack/netapp-credential-rotator/templates/crd/security.cloud.sap_netappcredentialrotators.yaml
+++ b/openstack/netapp-credential-rotator/templates/crd/security.cloud.sap_netappcredentialrotators.yaml
@@ -15,18 +15,15 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.appUser
+      name: App User
+      type: string
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Stopped")].status
-      name: Stopped
+    - jsonPath: .status.ready
+      name: Ready
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Stopped")].reason
-      name: Reason
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Stopped")].lastTransitionTime
-      name: Since
-      type: date
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -144,6 +141,12 @@ spec:
                 - RotateUserCredential
                 - RotateApplicationSecret
                 - Finalizing
+                type: string
+              ready:
+                enum:
+                - "True"
+                - Degraded
+                - Stopped
                 type: string
             type: object
         type: object


### PR DESCRIPTION
## Summary

- Add `App User` (`.spec.appUser`) and `Ready` (`.status.ready`) print columns to `kubectl get netappcredentials`
- Replace the Stopped/Reason/Since condition columns (which were always empty) with a single `Ready` field: `True` / `Degraded` / `Stopped`
- Sync conditions schema: adds `ready` field enum and `conditions` array from upstream controller-gen output

## Test plan

- [ ] Deploy CRD to QA and verify `kubectl get netappcredentials` shows `APP USER | PHASE | READY | AGE`