### PR TITLE
[octobus-query-exporter] fix Chart.lock out of sync with Chart.yaml

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:9258864e6058609cb179c13626600c67fa3da45ea2a675051ed616f274277cf1
-generated: "2026-07-21T22:41:42.948774+08:00"
+digest: sha256:490d10f8eeba5d570a18a4f24b4dd8dcad120c90b97d9eb9e76a2d8bce0878f6
+generated: "2026-08-12T14:23:12.399607+08:00"


### PR DESCRIPTION
## Problem

After PR #12512 bumped `octobus-query-exporter` from `1.0.34` to `1.0.35`, the `Chart.lock` digest was not regenerated. This causes a deployment error:

```
Error: the lock file (Chart.lock) is out of sync with the dependencies file (Chart.yaml). Please update the dependencies
```

## Fix

Ran `helm dependency update` in `prometheus-exporters/octobus-query-exporter/` to regenerate the `digest` and `generated` fields in `Chart.lock`.