### PR TITLE
barbican: TLS termination at Apache (BSI ADR-406 Step 2)

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.9.0
+version: 0.9.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     type: api
     component: barbican
   annotations:
-    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets{{- if .Values.tls.enabled }},{{ .Values.tls.certSecret }}{{- end }}"
     deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ required ".Values.api.replicas is missing" .Values.api.replicas }}
@@ -42,6 +42,9 @@ spec:
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        config.linkerd.io/skip-inbound-ports: "443"
         {{- end }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
@@ -115,6 +118,10 @@ spec:
           ports:
             - name: barbican-api
               containerPort: {{.Values.api_port_internal}}
+            {{- if .Values.tls.enabled }}
+            - name: barbican-tls
+              containerPort: 443
+            {{- end }}
           volumeMounts:
             - name: etcbarbican
               mountPath: /etc/barbican
@@ -145,6 +152,15 @@ spec:
               mountPath: /etc/apache2/conf-enabled/wsgi-barbican.conf
               subPath: wsgi-barbican.conf
               readOnly: true
+            {{- if .Values.tls.enabled }}
+            - name: barbican-etc
+              mountPath: /etc/apache2/conf-enabled/tls-hardening.conf
+              subPath: tls-hardening.conf
+              readOnly: true
+            - name: barbican-tls
+              mountPath: /etc/apache2/ssl
+              readOnly: true
+            {{- end }}
             - name: wsgi-barbican
               mountPath: /var/www/cgi-bin/barbican
             - name: barbican-apache-run
@@ -302,6 +318,16 @@ spec:
           configMap:
             name: barbican-bin
             defaultMode: 0555
+        {{- if .Values.tls.enabled }}
+        - name: barbican-tls
+          secret:
+            secretName: {{ required ".Values.tls.certSecret is required when tls.enabled" .Values.tls.certSecret }}
+            items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+        {{- end }}
         {{- if .Values.hsm.enabled }}
         - name: hsm
           secret:

--- a/openstack/barbican/templates/etc-configmap.yaml
+++ b/openstack/barbican/templates/etc-configmap.yaml
@@ -17,6 +17,10 @@ data:
 {{ include "loggerIni" .Values.logging | indent 4 }}
   wsgi-barbican.conf: |
 {{ include "wsgi_barbican_conf" . | indent 4 }}
+{{- if .Values.tls.enabled }}
+  tls-hardening.conf: |
+{{ include "tls_hardening_conf" . | indent 4 }}
+{{- end }}
 {{- if .Values.watcher.enabled }}
   watcher.yaml: |
 {{ include (print .Template.BasePath "/etc/_watcher.yaml.tpl") . | indent 4 }}

--- a/openstack/barbican/templates/etc/_tls-hardening.conf.tpl
+++ b/openstack/barbican/templates/etc/_tls-hardening.conf.tpl
@@ -1,0 +1,8 @@
+{{- define "tls_hardening_conf" }}
+SSLProtocol -all +TLSv1.2 +TLSv1.3
+SSLCipherSuite TLSv1.3 TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256
+SSLCipherSuite ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305
+SSLHonorCipherOrder on
+SSLCompression off
+SSLSessionTickets off
+{{- end }}

--- a/openstack/barbican/templates/etc/_wsgi-barbican.conf.tpl
+++ b/openstack/barbican/templates/etc/_wsgi-barbican.conf.tpl
@@ -48,4 +48,40 @@ Listen 0.0.0.0:{{ .Values.api_port_internal }}
 
     KeepAliveTimeout 61
 </VirtualHost>
+
+{{- if .Values.tls.enabled }}
+LoadModule ssl_module /usr/lib/apache2/modules/mod_ssl.so
+Listen 0.0.0.0:443
+<VirtualHost *:443>
+    ServerName {{ include "barbican_api_endpoint_host_public" . }}
+
+    SSLEngine on
+    SSLCertificateFile    /etc/apache2/ssl/tls.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/tls.key
+    Include /etc/apache2/conf-enabled/tls-hardening.conf
+
+    WSGIProcessGroup barbican-api
+    WSGIScriptAlias / /var/www/cgi-bin/barbican/barbican-wsgi-api
+    WSGIApplicationGroup %{GLOBAL}
+    WSGIPassAuthorization On
+    LimitRequestBody 114688
+
+    <Directory /var/www/cgi-bin/barbican>
+        Require all granted
+    </Directory>
+
+    ErrorLog /dev/stderr
+    {{- if .Values.use_json }}
+    SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+    CustomLog /dev/stdout json_combined env=!forwarded
+    CustomLog /dev/stdout json_proxy env=forwarded
+    {{- else }}
+    SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+    CustomLog /dev/stdout combined env=!forwarded
+    CustomLog /dev/stdout proxy env=forwarded
+    {{- end }}
+
+    KeepAliveTimeout 61
+</VirtualHost>
+{{- end }}
 {{- end }}

--- a/openstack/barbican/templates/ingress.yaml
+++ b/openstack/barbican/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 kind: Ingress
 apiVersion: networking.k8s.io/v1
 
@@ -39,3 +40,4 @@ spec:
               name: barbican-api
               port:
                 number: {{.Values.api_port_internal}}
+{{- end }}

--- a/openstack/barbican/templates/service-external.yaml
+++ b/openstack/barbican/templates/service-external.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.global.barbican_external_ip }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-external
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    system: openstack
+    type: api
+    component: barbican
+  annotations:
+    projectcalico.org/loadBalancerIPs: '["{{ .Values.global.barbican_external_ip }}"]'
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  externalIPs:
+    - {{ .Values.global.barbican_external_ip }}
+  selector:
+    name: barbican-api
+  ports:
+    - name: public
+      protocol: TCP
+      port: 443
+      targetPort: 443
+---
+apiVersion: disco.stable.sap.cc/v1
+kind: Record
+metadata:
+  name: {{ include "barbican_api_endpoint_host_public" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: A
+  record: {{ .Values.global.barbican_external_ip }}
+  hosts:
+    - {{ include "barbican_api_endpoint_host_public" . }}
+  zoneName: {{ .Values.global.region }}.{{ .Values.global.tld }}
+{{- end }}

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -53,6 +53,11 @@ api:
       cpu: "500m"
       memory: "1Gi"
 
+# TLS at Apache — not enabled here, flip in step 2
+tls:
+  enabled: false
+  certSecret: ""
+
 statsd:
   port: 9102
   image: 'shared-app-images/statsd-exporter'
@@ -478,6 +483,7 @@ tlsacme: true
 # first line of defence at the edge against oversized payloads and
 # connection floods before traffic reaches the Barbican API process.
 ingress:
+  enabled: true
   # Cap the maximum allowed request body size (secrets/payloads).
   # Requests exceeding this limit are rejected with HTTP 413.
   enableRequestSizeLimit: true


### PR DESCRIPTION
Step 2 of BSI ADR-406: TLS termination moves from nginx ingress to Apache mod_ssl on the pod.

Depends on #12554 (Apache migration — merged).

## Changes

- `service-external.yaml` (new): Calico BGP `LoadBalancer` port 443; `spec.externalIPs` required (`serviceExternalIPs` BGP config); disco `Record` CR for DNS A record (disco only manages DNS for Ingress, not LoadBalancer Services); `spec.zoneName` set to `<region>.<tld>`; gated on `global.barbican_external_ip`
- `etc/_tls-hardening.conf.tpl` (new): BSI TR-02102-2 cipher suites — TLS 1.2+1.3 only, `SSLHonorCipherOrder on`, compression off, session tickets off
- `etc/_wsgi-barbican.conf.tpl`: SSL `VirtualHost *:443` gated on `tls.enabled`; `LoadModule ssl_module` inline (no `a2enmod`, compatible with `readOnlyRootFilesystem: true`)
- `api-deployment.yaml`: `containerPort 443`; cert Secret mount at `/etc/apache2/ssl`; `config.linkerd.io/skip-inbound-ports: "443"`; reloader watches TLS cert secret for rotation pickup
- `ingress.yaml`: gated on `ingress.enabled` (default `true`) — ingress kept alive during TLS rollout as fallback; remove in a follow-up secrets change per region after BGP path confirmed
- `values.yaml`: `tls.enabled`, `tls.certSecret`, `ingress.enabled`
- `Chart.yaml`: `0.9.0` → `0.9.1`

## Cert management

cert-manager + `ClusterIssuer: digicert-issuer`. Secret `tls-keymanager-3-<region>-cloud-sap` provisioned per-region via `Certificate` CR. Already `READY: True` in qa-de-1 (age 202d) — Apache mounts the existing Secret.

## Rollout sequence per region

1. Set `global.barbican_external_ip`, `tls.enabled: true`, `tls.certSecret` in secrets repo
2. Deploy — TLS up, ingress still alive as fallback
3. Validate: TLS handshake, authenticated API call, check logs for `https://` scheme
4. Follow-up secrets change: `ingress.enabled: false` → removes nginx ingress

## Validated on qa-de-1

- TLS 1.3: `TLS_AES_256_GCM_SHA384`, digicert cert, Verification OK
- TLS 1.2: `ECDHE-RSA-AES256-GCM-SHA384` (BSI cipher)
- TLS 1.0/1.1 rejected
- Barbican middleware logs `https://` scheme confirming TLS e2e
- HSM PKCS#11 path intact, normal latency

## Test plan

- [x] `helm template` renders correctly with qa-de-1 values
- [x] Deploy to qa-de-1 — pods 6/6 Running
- [x] TLS 1.3 + TLS 1.2 (BSI ciphers) verified
- [x] TLS 1.0/1.1 rejected
- [x] Secret ops working through Apache + mod_ssl (HSM path intact)
- [x] Barbican middleware logs `https://` scheme
- [ ] Follow-up: set `ingress.enabled: false` per region after BGP path confirmed
