### PR TITLE
fix(archer): resolve keystone and NAD namespaces for non-colocated deploys

### DIFF
--- a/openstack/archer/templates/etc/_archer.ini.tpl
+++ b/openstack/archer/templates/etc/_archer.ini.tpl
@@ -16,7 +16,7 @@ enable_proxy_headers_parsing = true
 connection = postgresql://archer@{{ include "archer.fullname" . }}-postgresql:5432/archer?sslmode=disable&pool_max_conns=20
 
 [service_auth]
-auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
+auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.{{ .Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain" }}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Release.Name }}{{ .Values.global.user_suffix }}
 project_name = service
 project_domain_id = default

--- a/openstack/archer/templates/statefulset-network-agent.yaml
+++ b/openstack/archer/templates/statefulset-network-agent.yaml
@@ -44,7 +44,7 @@ spec:
         checksum/etc: {{ include (print $.Template.BasePath  "/configmap.yaml") $ | sha256sum }}
         checksum/neutron-linuxbridge-etc: {{ include (print $.Template.BasePath "/configmap-neutron-linuxbridge.yaml") $ | sha256sum }}
         checksum/neutron-linuxbridge-secret: {{ include (print $.Template.BasePath "/neutron-secret.yaml") $ | sha256sum }}
-        k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"{{ $agent.network_interface | default $.Values.cp_network_interface }}" }]'
+        k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "namespace": "{{ default $.Release.Namespace $.Values.global.keystoneNamespace }}", "interface":"{{ $agent.network_interface | default $.Values.cp_network_interface }}" }]'
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
         config.linkerd.io/skip-inbound-ports: "1-65535"
         config.linkerd.io/skip-outbound-ports: "1-65535"


### PR DESCRIPTION
When archer runs in its own namespace (rather than colocated with keystone in `monsoon3`), two references incorrectly resolved against the release namespace:

1. **`service_auth` `auth_url`** was built via the shared `utils` helper `keystone_api_endpoint_host_internal`, which derives the host from `.Release.Namespace`, rendering an unresolvable `keystone.<release-ns>.svc...`. Now built from `global.keystoneNamespace`, matching the castellum/hermes/keppel/limes charts.

2. **The `cbr1-bridge` NetworkAttachmentDefinition** annotation was unqualified, so Multus looked for the NAD in the pod's own namespace and failed sandbox setup for the network agents. Now qualified with `global.keystoneNamespace`.

Both fall back to the release namespace, so clusters where archer runs in `monsoon3` render unchanged.