### PR TITLE
hpe-dl380-gen12: add settings

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.43
+version: 0.2.44
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/bios_settings/hpe-dl380-gen12.yaml
+++ b/system/metal-settings/bios_settings/hpe-dl380-gen12.yaml
@@ -1,0 +1,20 @@
+settingsFlow:
+- name: preset
+  priority: 5
+  settings:
+    WorkloadProfile: Virtualization-MaxPerformance
+- name: settings
+  priority: 10
+  settings:
+    WorkloadProfile: Custom
+    FanFailPolicy: Allow
+    SubNumaClustering: Disabled
+    ThermalConfig: IncreasedCooling
+    HttpSupport: Disabled
+    IpxeBootOrder: Enabled
+    OcpBNicBoot1: NetworkBoot
+    PreBootNetwork: OcpBNicPort1
+    PrebootNetworkEnvPolicy: IPv4
+    Slot2NicBoot1: Disabled
+    Slot2NicBoot2: Disabled
+    UrlBootFile: ""

--- a/system/metal-settings/tests/bios_settings_test.yaml
+++ b/system/metal-settings/tests/bios_settings_test.yaml
@@ -9,7 +9,7 @@ tests:
   - it: should render BIOSSettingsSet resources by default
     asserts:
       - hasDocuments:
-          count: 126
+          count: 132
       - isKind:
           of: BIOSSettingsSet
 

--- a/system/metal-settings/tests/bmc_settings_test.yaml
+++ b/system/metal-settings/tests/bmc_settings_test.yaml
@@ -11,7 +11,7 @@ tests:
       bmcSettings.enabled: true
     asserts:
       - hasDocuments:
-          count: 126
+          count: 132
       - isKind:
           of: BMCSettingsSet
 

--- a/system/metal-settings/values.yaml
+++ b/system/metal-settings/values.yaml
@@ -427,8 +427,10 @@ machines:
 
       proliant-dl380-gen12:
         model: proliant-dl380-gen12
+        clusterTypes: *defaultClusterTypes
         bios:
           version: "U68 v1.52 (10/03/2025)"
+          settingsFileName: hpe-dl380-gen12.yaml
           imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/hpe/proliant-dl380-gen12/U68_1.52_10_03_2025.fwpkg"
         bmc:
           version: "1.18.00 Oct 09 2025"


### PR DESCRIPTION
add missing settings for the hpe proliant dl380-gen12.