### PR TITLE
fix(metal-operator-dhcp): re-add service IP in main container on restart

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.4.3
+version: 2.4.4
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
@@ -91,6 +91,13 @@ data:
     echo "Outgoing inteface is ${INTERFACE}"
     echo "${INTERFACE}" > /shared/interface
 
+{{ if .Values.dnsmasq.service }}
+    # Re-add the service IP on every container start. The init container adds it
+    # on pod creation, but the preStop hook removes it on liveness-triggered
+    # restarts. Without this, dnsmasq cannot bind to listen-address after a restart.
+    ip addr add ${DHCPSERVERIP}/32 dev ${INTERFACE} 2>/dev/null || true
+{{ end }}
+
     {{- if .Values.ipxe.efi.host }}
     curl -o /shared/tftpboot/{{ .Values.ipxe.efi.file }} {{ .Values.ipxe.efi.host }}/{{ .Values.ipxe.efi.file }}
     {{- else }}


### PR DESCRIPTION
## Problem

When `dnsmasq.service` is enabled, the externalIP (`/32`) is added to the node interface by the **init container** (`dhcp-init.sh`), which only runs on pod creation. The **preStop hook** (`dhcp-stop.sh`) removes this IP on every container termination — including liveness-triggered kills.

Since Kubernetes restarts the **container** (not the pod) on liveness failures, the init container does not re-run. The IP is permanently lost, dnsmasq cannot bind to its `listen-address`, the TFTP port (69) never comes up, and the liveness probe fails indefinitely — a permanent crash loop.

**Observed:** 202+ restarts in one region, while another region (which never had an initial liveness hiccup) remained stable.

## Fix

Add an idempotent `ip addr add ${DHCPSERVERIP}/32 dev ${INTERFACE}` to `initdnsmasq.sh` (the main container entrypoint). This ensures the IP is restored on every container restart, breaking the crash loop.

The command uses `2>/dev/null || true` so it is harmless when the IP already exists (normal startup after init container).

## Changes

- `templates/configmap-dnsmasq.yaml`: add `ip addr add` in `initdnsmasq.sh` (gated by `.Values.dnsmasq.service`)
- `Chart.yaml`: bump version 2.4.3 → 2.4.4