### PR TITLE
dell-r770: add 2nd biossettingsset due to inconsistent nic names

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.45
+version: 0.2.46
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/bios_settings/dell-r770-nic-slot7.yaml
+++ b/system/metal-settings/bios_settings/dell-r770-nic-slot7.yaml
@@ -3,12 +3,12 @@ settingsFlow:
   priority: 15
   settings:
     PxeDev1EnDis: Enabled
-- name: PXEBootWithNIC.Slot.10-1-1
+- name: PXEBootWithNIC.Slot.7-1-1
   priority: 20
   settings:
     MemOpMode: OptimizerMode
     PwrButton: Disabled
-    PxeDev1Interface: NIC.Slot.10-1-1
+    PxeDev1Interface: NIC.Slot.7-1-1
     PxeDev1Protocol: IPv4
     PxeDev1VlanEnDis: Disabled
     PxeDev2EnDis: Disabled

--- a/system/metal-settings/tests/bios_settings_test.yaml
+++ b/system/metal-settings/tests/bios_settings_test.yaml
@@ -9,7 +9,7 @@ tests:
   - it: should render BIOSSettingsSet resources by default
     asserts:
       - hasDocuments:
-          count: 132
+          count: 138
       - isKind:
           of: BIOSSettingsSet
 

--- a/system/metal-settings/values.yaml
+++ b/system/metal-settings/values.yaml
@@ -284,10 +284,25 @@ machines:
           version: "1.8.5"
           settingsFileName: dell-r770.yaml
           imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r770/BIOS_VTF4T_WN64_1.8.5.EXE"
+          settingsParams:
+            serverFilter:
+              excluded: [node004-bb098]
         bmc:
           version: "1.30.30.50"
           settingsFileName: dell-r770.yaml
           imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r770/iDRAC-with-Lifecycle-Controller_Firmware_11F63_WN64_1.30.30.50_A00.EXE"
+
+      poweredge-r770-nic-slot7:
+        model: poweredge-r770
+        clusterTypes: *defaultClusterTypes
+        bios:
+          version: "1.8.5"
+          settingsFileName: dell-r770-nic-slot7.yaml
+          imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r770/BIOS_VTF4T_WN64_1.8.5.EXE"
+          settingsParams:
+            serverFilter:
+              included: [node004-bb098]
+            setMetadataName: dell-poweredge-r770-nic-slot7
 
       poweredge-r7715:
         model: poweredge-r7715


### PR DESCRIPTION
For reasons one dell-r770 has NIC10 as L1 while the other has NIC7. 
This PR adds a second `biossettingsset` to match that and update tests