### PR TITLE
Allow changing API group of a resource

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.45
+version: 0.2.46
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/templates/_helpers.tpl
+++ b/system/metal-settings/templates/_helpers.tpl
@@ -85,16 +85,19 @@ true
 {{/*
 Render server selector matchExpressions from a serverFilters object.
 Expected input:
-  dict "serverFilters" (dict "included" (list ...) "excluded" (list ...))
+  dict "serverFilters" (dict "included" (list ...) "excluded" (list ...)) "labelKey" $.Values.labelKeys.serverName
+
+"labelKey" is optional and defaults to "kubernetes.metal.cloud.sap/name" if not provided.
 
 Returns empty string if both lists are empty.
 */}}
 {{- define "metal-settings.serverMatchExpressions" -}}
 {{- $serverFilters := .serverFilters -}}
+{{- $labelKey := .labelKey | default "kubernetes.metal.cloud.sap/name" -}}
 {{- if or $serverFilters.included $serverFilters.excluded -}}
 matchExpressions:
 {{- if $serverFilters.included }}
-  - key: kubernetes.metal.cloud.sap/name
+  - key: {{ $labelKey }}
     operator: In
     values:
 {{- range $serverFilters.included }}
@@ -102,7 +105,7 @@ matchExpressions:
 {{- end }}
 {{- end }}
 {{- if $serverFilters.excluded }}
-  - key: kubernetes.metal.cloud.sap/name
+  - key: {{ $labelKey }}
     operator: NotIn
     values:
 {{- range $serverFilters.excluded }}

--- a/system/metal-settings/templates/bios_settings.yaml
+++ b/system/metal-settings/templates/bios_settings.yaml
@@ -21,16 +21,16 @@
 {{- $explicitName := (get $settingsParams "setMetadataName") }}
 {{- $withCluster := printf "%s-%s" $explicitName (lower $clusterType) }}
 {{- $resourceName := ternary $withCluster $defaultName (ne $explicitName "") }}
-apiVersion: metal.ironcore.dev/v1alpha1
+apiVersion: {{ $.Values.apiVersions.biosSettingsSet }}
 kind: BIOSSettingsSet
 metadata:
   name: {{ $resourceName }}
 spec:
   serverSelector:
     matchLabels:
-      kubernetes.metal.cloud.sap/type: {{ $model }}
-      kubernetes.metal.cloud.sap/cluster-type: {{ $clusterType }}
-{{- $serverMatchExpressions := include "metal-settings.serverMatchExpressions" (dict "serverFilters" $serverFilters) }}
+      {{ $.Values.labelKeys.type }}: {{ $model }}
+      {{ $.Values.labelKeys.clusterType }}: {{ $clusterType }}
+{{- $serverMatchExpressions := include "metal-settings.serverMatchExpressions" (dict "serverFilters" $serverFilters "labelKey" $.Values.labelKeys.serverName) }}
 {{- if $serverMatchExpressions }}
 {{ $serverMatchExpressions | nindent 4 }}
 {{- end }}

--- a/system/metal-settings/templates/bios_versions.yaml
+++ b/system/metal-settings/templates/bios_versions.yaml
@@ -20,7 +20,7 @@
 
 {{/* Model and Version filtering */}}
 {{- if and (include "metal-settings.shouldInclude" (dict "item" $model "filters" $.Values.biosVersions.filters.models)) (include "metal-settings.shouldInclude" (dict "item" $version "filters" $.Values.biosVersions.filters.versions)) }}
-apiVersion: metal.ironcore.dev/v1alpha1
+apiVersion: {{ $.Values.apiVersions.biosVersionSet }}
 kind: BIOSVersionSet
 metadata:
   {{- $defaultName := printf "%s-%s" (lower $vendor) (lower $model) }}
@@ -33,8 +33,8 @@ metadata:
 spec:
   serverSelector:
     matchLabels:
-      kubernetes.metal.cloud.sap/type: {{ $model }}
-{{- $serverMatchExpressions := include "metal-settings.serverMatchExpressions" (dict "serverFilters" $serverFilters) }}
+      {{ $.Values.labelKeys.type }}: {{ $model }}
+{{- $serverMatchExpressions := include "metal-settings.serverMatchExpressions" (dict "serverFilters" $serverFilters "labelKey" $.Values.labelKeys.serverName) }}
 {{- if $serverMatchExpressions }}
 {{ $serverMatchExpressions | nindent 4 }}
 {{- end }}

--- a/system/metal-settings/templates/bmc_settings.yaml
+++ b/system/metal-settings/templates/bmc_settings.yaml
@@ -21,16 +21,16 @@
 {{- $explicitName := (get $settingsParams "setMetadataName") }}
 {{- $withCluster := printf "%s-%s" $explicitName (lower $clusterType) }}
 {{- $resourceName := ternary $withCluster $defaultName (ne $explicitName "") }}
-apiVersion: metal.ironcore.dev/v1alpha1
+apiVersion: {{ $.Values.apiVersions.bmcSettingsSet }}
 kind: BMCSettingsSet
 metadata:
   name: {{ $resourceName }}
 spec:
   bmcSelector:
     matchLabels:
-      kubernetes.metal.cloud.sap/type: {{ $model }}
-      kubernetes.metal.cloud.sap/cluster-type: {{ $clusterType }}
-{{- $serverMatchExpressions := include "metal-settings.serverMatchExpressions" (dict "serverFilters" $serverFilters) }}
+      {{ $.Values.labelKeys.type }}: {{ $model }}
+      {{ $.Values.labelKeys.clusterType }}: {{ $clusterType }}
+{{- $serverMatchExpressions := include "metal-settings.serverMatchExpressions" (dict "serverFilters" $serverFilters "labelKey" $.Values.labelKeys.serverName) }}
 {{- if $serverMatchExpressions }}
 {{ $serverMatchExpressions | nindent 4 }}
 {{- end }}

--- a/system/metal-settings/templates/bmc_versions.yaml
+++ b/system/metal-settings/templates/bmc_versions.yaml
@@ -20,7 +20,7 @@
 
 {{/* Model and Version filtering */}}
 {{- if and (include "metal-settings.shouldInclude" (dict "item" $model "filters" $.Values.bmcVersions.filters.models)) (include "metal-settings.shouldInclude" (dict "item" $version "filters" $.Values.bmcVersions.filters.versions)) }}
-apiVersion: metal.ironcore.dev/v1alpha1
+apiVersion: {{ $.Values.apiVersions.bmcVersionSet }}
 kind: BMCVersionSet
 metadata:
   {{- $defaultName := printf "%s-%s" (lower $vendor) (lower $model) }}
@@ -33,8 +33,8 @@ metadata:
 spec:
   bmcSelector:
     matchLabels:
-      kubernetes.metal.cloud.sap/type: {{ $model }}
-{{- $serverMatchExpressions := include "metal-settings.serverMatchExpressions" (dict "serverFilters" $serverFilters) }}
+      {{ $.Values.labelKeys.type }}: {{ $model }}
+{{- $serverMatchExpressions := include "metal-settings.serverMatchExpressions" (dict "serverFilters" $serverFilters "labelKey" $.Values.labelKeys.serverName) }}
 {{- if $serverMatchExpressions }}
 {{ $serverMatchExpressions | nindent 4 }}
 {{- end }}

--- a/system/metal-settings/values.yaml
+++ b/system/metal-settings/values.yaml
@@ -101,6 +101,35 @@ bmcVersions:
       included: []
       excluded: []
 
+# Label keys used to build serverSelector/bmcSelector matchLabels and
+# matchExpressions in the generated BIOSSettingsSet/BMCSettingsSet/
+# BIOSVersionSet/BMCVersionSet resources.
+#
+# Override these per-cluster to support migrations where a newer/renamed
+# label group is used to identify servers (e.g. testing a new
+# "kubernetes.metal.cloud.sap/cluster-type" replacement on a subset of
+# clusters before rolling it out everywhere).
+labelKeys:
+  type: "kubernetes.metal.cloud.sap/type"
+  clusterType: "kubernetes.metal.cloud.sap/cluster-type"
+  serverName: "kubernetes.metal.cloud.sap/name"
+
+# apiVersion used for the generated BIOSSettingsSet/BMCSettingsSet/
+# BIOSVersionSet/BMCVersionSet resources.
+#
+# metal-operator (single-group project) serves these kinds under
+# "metal.ironcore.dev/v1alpha1". metal-maintenance-operator (multigroup
+# project) serves the same kinds under group-qualified versions, e.g.
+# "system.metal.ironcore.dev/v1alpha1" for BIOSSettingsSet/BIOSVersionSet and
+# "baseboard.metal.ironcore.dev/v1alpha1" for BMCSettingsSet/BMCVersionSet.
+# Override per-cluster to test migrating from metal-operator to
+# metal-maintenance-operator.
+apiVersions:
+  biosSettingsSet: "metal.ironcore.dev/v1alpha1"
+  bmcSettingsSet: "metal.ironcore.dev/v1alpha1"
+  biosVersionSet: "metal.ironcore.dev/v1alpha1"
+  bmcVersionSet: "metal.ironcore.dev/v1alpha1"
+
 # Cluster-specific values injected into the metal-bmc-settings ConfigMap.
 # These are region/cluster-level overrides consumed by BMCSettings variables at reconcile time.
 clusterConfig:


### PR DESCRIPTION
The resources have moved to new metal-maintenance-operator. allow option to move the resources to specified API group.