### PR TITLE
feat(cc-runtime-cluster): make calico veth_mtu configurable

### DIFF
--- a/system/cc-runtime-cluster/Chart.yaml
+++ b/system/cc-runtime-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-runtime-cluster
 description: Converged Cloud Cluster API Runtime Cluster
 type: application
-version: 0.9.2
+version: 0.9.3
 appVersion: "0.1.0"

--- a/system/cc-runtime-cluster/templates/helmchartproxy-calico.yaml
+++ b/system/cc-runtime-cluster/templates/helmchartproxy-calico.yaml
@@ -25,6 +25,7 @@ spec:
       global:
         clusterCIDR: {{ $.Values.controlplane.podSubnet }}
       config:
+        veth_mtu: {{ $.Values.calico.vethMTU }}
         monitoring:
           enabled: false
         felix:

--- a/system/cc-runtime-cluster/values.yaml
+++ b/system/cc-runtime-cluster/values.yaml
@@ -77,6 +77,9 @@ machineHealthCheck:
   enabled: true
   nodeStartupTimeoutSeconds: 3600
 
+calico:
+  vethMTU: 8950
+
 cloudProviderMetal:
   enabled: true
   image:


### PR DESCRIPTION
## Summary

Expose `calico.vethMTU` as a configurable value in the cc-runtime-cluster chart, defaulting to 8950 (current behavior).

## Motivation

When the physical underlay MTU is reduced (e.g., from 8950 to 1500), calico's veth MTU must be adjusted accordingly to prevent MTU black holes. With IPIP overlay, the correct veth MTU is `underlay_mtu - 20`.

Previously this value was not configurable and always inherited the default from the calico subchart (8950).

## Changes

- `values.yaml`: Add `calico.vethMTU` with default 8950
- `helmchartproxy-calico.yaml`: Template `veth_mtu` from the new value
- Bump chart version 0.9.2 → 0.9.3