### PR TITLE
fix(archer): normalize migration Job name from image tag

### DIFF
--- a/openstack/archer/Chart.yaml
+++ b/openstack/archer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/openstack/archer/templates/job-migration.yaml
+++ b/openstack/archer/templates/job-migration.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "archer.fullname" . }}-migration-{{ .Values.image.tag | required ".Values.image.tag is required" }}
+  name: {{ include "archer.fullname" . }}-migration-{{ .Values.image.tag | required ".Values.image.tag is required" | replace "." "-" }}
   labels:
     {{- include "archer.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
The migration Job name is derived from `.Values.image.tag`. Image tags that contain dots (e.g. a semver tag like `1.2.3`) produce an awkward Job name and can collide with contexts that expect RFC 1123 label segments.

Sanitize the tag with sprig `replace "." "-"` so the generated Job name stays valid and predictable.

Bumps the archer chart version to 0.1.3.