### PR TITLE
fix(owner-info): correct support-group from containers to network-api for archer

### DIFF
--- a/global/cc-landing-page/values.yaml
+++ b/global/cc-landing-page/values.yaml
@@ -1,6 +1,6 @@
 owner-info:
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/global/landing/
-  support-group: containers
+  support-group: src
   service: cc-landing-page
   maintainers:
     - Esther Schmitz

--- a/global/ccloud-hedgedoc/values.yaml
+++ b/global/ccloud-hedgedoc/values.yaml
@@ -1,5 +1,5 @@
 owner-info:
-  support-group: containers
+  support-group: src
   service: hedgedoc
   maintainers:
     - Stefan Majewsky

--- a/global/vault-tec/values.yaml
+++ b/global/vault-tec/values.yaml
@@ -18,7 +18,7 @@ config:
     period: 5m
     jitter: 1.1
 owner-info:
-  support-group: containers
+  support-group: src
   service: vault-tec
   maintainers:
     - Erik Schubert

--- a/openstack/archer/values.yaml
+++ b/openstack/archer/values.yaml
@@ -108,7 +108,7 @@ alerts:
   tier: os
 
 owner-info:
-  support-group: containers
+  support-group: network-api
   service: archer
   maintainers:
     - Andrew Karpow

--- a/openstack/aurora/values.yaml
+++ b/openstack/aurora/values.yaml
@@ -11,7 +11,7 @@ image:
 port: 3000
 
 owner-info:
-  support-group: containers
+  support-group: src
   service: aurora
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/aurora
   maintainers:

--- a/openstack/backup-replication/values.yaml
+++ b/openstack/backup-replication/values.yaml
@@ -4,7 +4,7 @@ global:
   linkerd_requested: true
 
 owner-info:
-  support-group: containers
+  support-group: src
   service: backup
   maintainers:
     - Stefan Majewsky

--- a/openstack/castellum/values.yaml
+++ b/openstack/castellum/values.yaml
@@ -6,7 +6,7 @@ linkerd-support:
   annotate_namespace: true
 
 owner-info:
-  support-group: containers
+  support-group: src
   service: castellum
   maintainers:
     - Stefan Majewsky

--- a/openstack/content-repo/values.yaml
+++ b/openstack/content-repo/values.yaml
@@ -8,7 +8,7 @@ linkerd-support:
   annotate_namespace: true
 
 owner-info:
-  support-group: containers
+  support-group: src
   service: repo
   maintainers:
     - Stefan Majewsky

--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -103,7 +103,7 @@ pgmetrics:
     service: elektra
 
 owner-info:
-  support-group: containers
+  support-group: src
   service: elektra
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/elektra
   maintainers:

--- a/openstack/keppel/values.yaml
+++ b/openstack/keppel/values.yaml
@@ -1,5 +1,5 @@
 owner-info:
-  support-group: containers
+  support-group: src
   service: keppel
   maintainers:
     - Stefan Majewsky

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -21,7 +21,7 @@ linkerd-support:
   annotate_namespace: true
 
 owner-info:
-  support-group: containers
+  support-group: src
   service: limes
   maintainers:
     - Stefan Majewsky

--- a/system/gatekeeper/values.yaml
+++ b/system/gatekeeper/values.yaml
@@ -1,5 +1,5 @@
 owner-info:
-  support-group: containers
+  support-group: src
   service: gatekeeper
   maintainers:
     - Stefan Majewsky

--- a/system/hubcopter/values.yaml
+++ b/system/hubcopter/values.yaml
@@ -5,7 +5,7 @@ linkerd-support:
   annotate_namespace: true
 
 owner-info:
-  support-group: containers
+  support-group: src
   service: hubcopter
   maintainers:
     - Sandro Jäckel

--- a/system/surveyor/values.yaml
+++ b/system/surveyor/values.yaml
@@ -4,7 +4,7 @@ linkerd-support:
   annotate_namespace: true
 
 owner-info:
-  support-group: containers
+  support-group: src
   service: surveyor
   maintainers:
     - Stefan Majewsky

--- a/system/tenso/values.yaml
+++ b/system/tenso/values.yaml
@@ -5,7 +5,7 @@ linkerd-support:
   annotate_namespace: true
 
 owner-info:
-  support-group: containers
+  support-group: src
   service: tenso
   maintainers:
     - Stefan Majewsky


### PR DESCRIPTION
## Summary

- Corrects `owner-info.support-group` from `containers` to `network-api` in `openstack/archer`
- Archer is maintained by the network-api team (`@notandy`) and was incorrectly assigned to `containers`

## Background

The `owner-info.support-group` field is injected as `ccloud.sap.com/support-group` label by the owner-label-injector webhook. Heureka reads these labels to assign services to support groups. The incorrect assignment caused archer to appear under `containers` in Heureka.

Tracked in: https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1387

## Test plan

- [ ] Verify `owner-info.support-group: network-api` in `openstack/archer/values.yaml`
- [ ] After merge and rollout, confirm archer moves from `containers` to `network-api` in Heureka