### PR TITLE
fix(manila): gazpacho/2026.1 compatibility fixes

### DIFF
--- a/openstack/manila/templates/bin/_manila_api.sh.tpl
+++ b/openstack/manila/templates/bin/_manila_api.sh.tpl
@@ -20,9 +20,23 @@ COMMAND="${@:-start}"
 
 function start () {
 
-  for MANILA_WSGI_SCRIPT in manila-wsgi; do
-    cp -a $(type -p ${MANILA_WSGI_SCRIPT}) /var/www/cgi-bin/manila/
-  done
+  if type -p manila-wsgi > /dev/null; then
+    cp -a $(type -p manila-wsgi) /var/www/cgi-bin/manila/manila-wsgi
+  else
+    cat > /var/www/cgi-bin/manila/manila-wsgi <<'WSGI'
+import threading
+_app = None
+_lock = threading.Lock()
+with _lock:
+    if _app is None:
+        from oslo_config import cfg
+        cfg.CONF.reset()
+        from manila.wsgi.wsgi import initialize_application
+        _app = initialize_application()
+application = _app
+WSGI
+    chmod 755 /var/www/cgi-bin/manila/manila-wsgi
+  fi
 
   a2dismod status
 

--- a/openstack/manila/templates/etc/_api-paste.ini.tpl
+++ b/openstack/manila/templates/etc/_api-paste.ini.tpl
@@ -5,6 +5,7 @@
 [composite:osapi_share]
 use = call:manila.api:root_app_factory
 /: apiversions
+/healthcheck: healthcheck
 {{- if .Values.api_v1_enabled }}
 /v1: openstack_share_api
 {{- end }}
@@ -53,7 +54,7 @@ paste.app_factory = manila.api.v1.router:APIRouter.factory
 paste.app_factory = manila.api.v2.router:APIRouter.factory
 
 [pipeline:apiversions]
-pipeline = cors healthcheck faultwrap http_proxy_to_wsgi osshareversionapp
+pipeline = cors faultwrap http_proxy_to_wsgi osshareversionapp
 
 [app:osshareversionapp]
 paste.app_factory = manila.api.versions:VersionsRouter.factory
@@ -75,8 +76,8 @@ oslo_config_project = manila
 [filter:osprofiler]
 paste.filter_factory = osprofiler.web:WsgiMiddleware.factory
 
-[filter:healthcheck]
-paste.filter_factory = oslo_middleware:Healthcheck.factory
+[app:healthcheck]
+paste.app_factory = oslo_middleware:Healthcheck.app_factory
 backends = disable_by_file
 disable_by_file_path = /etc/manila/healthcheck_disable
 


### PR DESCRIPTION
## Summary

Two compatibility fixes discovered during the gazpacho (2026.1) dev deployment in qa-de-1.

### fix(manila): handle missing manila-wsgi binary with fallback

Gazpacho/2026.1 removed `manila-wsgi` (pbr `wsgi_scripts` dropped, migrated to
`pyproject.toml` which only registers `manila-api`). Without this fix, the API pod
crashes on start with "manila-wsgi: not found".

Changes to `_manila_api.sh.tpl`:
- If `manila-wsgi` exists, copy it as before
- Otherwise, generate a minimal WSGI app script that calls `initialize_application()`
  (includes `CONF.reset()` to clear oslo.config parsed state before re-entry)
- Always places the script at `manila-wsgi` so Apache config stays unchanged

### fix(manila): update api-paste.ini for oslo_middleware healthcheck API change

`oslo_middleware >= 6.x` removed support for `HealthcheckMiddleware` as a WSGI filter.
It must now be deployed as a standalone app. Without this fix, the API fails to start
with: `HealthcheckMiddleware should be deployed as an app, not a filter`.

Changes to `_api-paste.ini.tpl`:
- Add `/healthcheck: healthcheck` route to `[composite:osapi_share]`
- Change `[filter:healthcheck]` → `[app:healthcheck]` with `app_factory`
- Remove `healthcheck` from `[pipeline:apiversions]`

## Test plan

- [x] Verified in qa-de-1 with manila-gazpacho (2026.1) — all API pods Running 3/3
- [x] Backward compatible: if `manila-wsgi` binary exists (epoxy and earlier), original path is taken