### PR TITLE
fix(owner-info): correct support-group for vault-tec

### DIFF
--- a/global/vault-tec/values.yaml
+++ b/global/vault-tec/values.yaml
@@ -18,7 +18,7 @@ config:
     period: 5m
     jitter: 1.1
 owner-info:
-  support-group: containers
+  support-group: src
   service: vault-tec
   maintainers:
     - Erik Schubert

--- a/openstack/archer/values.yaml
+++ b/openstack/archer/values.yaml
@@ -108,7 +108,7 @@ alerts:
   tier: os
 
 owner-info:
-  support-group: network-api
+  support-group: containers
   service: archer
   maintainers:
     - Andrew Karpow

--- a/openstack/archer/values.yaml
+++ b/openstack/archer/values.yaml
@@ -108,7 +108,7 @@ alerts:
   tier: os
 
 owner-info:
-  support-group: containers
+  support-group: network-api
   service: archer
   maintainers:
     - Andrew Karpow


### PR DESCRIPTION
## Summary

- \`global/vault-tec\`: \`support-group: containers\` → \`support-group: src\` (Security Engineering team, maintained by Erik Schubert and Fabian Ruff)

## Background

Without a correct \`owner-info\` block, the owner-label-injector webhook injects the wrong \`ccloud.sap.com/support-group\` label, causing vault-tec to appear under \`containers\` instead of \`src\` (Security Engineering) in Heureka.

Note: \`archer\` was initially included in this PR but reverted — it remains at \`containers\` until a management-level team migration is agreed upon (confirmed by Franziska Lichtblau, network-api team).

## Test plan

- [ ] Verify \`support-group: src\` in \`global/vault-tec/values.yaml\`
- [ ] After merge and rollout, confirm vault-tec appears under \`src\` in Heureka