### PR TITLE
limes: add .Values.limes.customer_seed

### DIFF
--- a/openstack/limes/templates/seed-customer.yaml
+++ b/openstack/limes/templates/seed-customer.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.limes.customer_seed -}}
+
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: OpenstackSeed
+metadata:
+  name: limes-customer-seed
+
+spec: {{ .Values.limes.customer_seed | toYaml | nindent 2 }}
+
+{{- end -}}

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -140,6 +140,11 @@ limes:
   resources:
     enabled: false
 
+  # May contain the `spec` section of an OpenstackSeed object.
+  # Intended for giving specialized role assignments to customers as part of support tickets
+  # (esp. cross-domain role assignments that are difficult to set up without cloud-admin access).
+  customer_seed: null
+
 postgresql:
   postgresVersion: 18
   persistence:


### PR DESCRIPTION
As explained in the code comment, we have a ticket asking us to add specific role assignments. I don't want to put customer data in this repo, so this facility allows the respective seed to come in from the secrets repo.