### PR TITLE
metal-settings: fix integer values for lenovo sr850-v3-new

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.46
+version: 0.2.47
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/bios_settings/lenovo-sr850-v3-new.yaml
+++ b/system/metal-settings/bios_settings/lenovo-sr850-v3-new.yaml
@@ -34,7 +34,7 @@ settingsFlow:
     Processors_TurboMode: "Enabled"
     Processors_UPILinkFrequency: "MaximumPerformance"
     Processors_UPIPrefetcher: "Enabled"
-    Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot1PhysicalPort1LogicalPort1_MaximumNumberofPFMSI_XVectors: "128"
-    Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot1PhysicalPort2LogicalPort1_MaximumNumberofPFMSI_XVectors: "128"
-    Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot2PhysicalPort1LogicalPort1_MaximumNumberofPFMSI_XVectors: "128"
-    Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot2PhysicalPort2LogicalPort1_MaximumNumberofPFMSI_XVectors: "128"
+    Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot1PhysicalPort1LogicalPort1_MaximumNumberofPFMSI_XVectors: 128
+    Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot1PhysicalPort2LogicalPort1_MaximumNumberofPFMSI_XVectors: 128
+    Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot2PhysicalPort1LogicalPort1_MaximumNumberofPFMSI_XVectors: 128
+    Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot2PhysicalPort2LogicalPort1_MaximumNumberofPFMSI_XVectors: 128


### PR DESCRIPTION
applying those settings fails with this error:

```
Settings provided is invalid. error: Settings Name: Broadcom57508100GbEQSFP562_PortOCPEthernetAdapter__Slot2PhysicalPort2LogicalPort1_MaximumNumberofPFMSI_XVectors
        Settings Value: 128
        Error: attribute value has wrong type. needed 'Integer'
```

the PR should help.