### PR TITLE
fix(metal-operator-dhcp): remove TFTP port from Service to fix bind conflict

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.4.4
+version: 2.4.5
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/service.yaml
+++ b/system/metal-operator-dhcp/templates/service.yaml
@@ -12,10 +12,10 @@ spec:
     port: 67
     protocol: UDP
     targetPort: 67
-  - name: dhcp-69
-    port: 69
-    protocol: UDP
-    targetPort: 69
+  # TFTP (port 69) is intentionally NOT exposed via the Service.
+  # kube-proxy DNAT rewrites the destination IP which breaks TFTP because
+  # dnsmasq binds to listen-address (externalIP) only. Instead, TFTP works
+  # directly via hostNetwork + ip addr add of the externalIP on the node.
   type: LoadBalancer
   loadBalancerIP: {{ .Values.dnsmasq.externalIP }}
   externalTrafficPolicy: Local


### PR DESCRIPTION
## Problem

After pod rescheduling, TFTP stops working for PXE clients:
- `curl --connect-timeout 3 tftp://10.245.234.14/snponly.efi` times out
- tcpdump shows packets arriving with destination rewritten to the node IP

## Root Cause

With port 69 in the LoadBalancer Service, kube-proxy creates DNAT rules that rewrite the destination IP from the externalIP (`10.245.234.14`) to the node/endpoint IP (`10.245.234.35`). dnsmasq only listens on the externalIP (via `listen-address`), so DNATed packets are never delivered.

The existing PREROUTING ACCEPT rule (inserted by dhcp-init.sh to bypass DNAT) may become ineffective after pod rescheduling if kube-proxy re-syncs its iptables chains and re-asserts the `KUBE-SERVICES` jump above the ACCEPT rule.

## Fix

Remove port 69 (TFTP) from the Service definition. TFTP works directly via `hostNetwork` + `ip addr add` of the externalIP on the node interface — no Service-level load balancing is needed. Without port 69 in the Service, kube-proxy creates no DNAT rules for TFTP traffic.

The existing PREROUTING ACCEPT iptables rule in dhcp-init.sh becomes a harmless no-op and can be cleaned up in a follow-up.

## Validation

After deploying:
- `ss -lun | grep :69` shows dnsmasq bound to `10.245.234.14:69`
- `curl --connect-timeout 3 tftp://<externalIP>/snponly.efi` works
- PXE clients successfully download boot files via TFTP