### PR TITLE
barbican: fix apache startup errors with readOnlyRootFilesystem

### DIFF
--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -151,6 +151,8 @@ spec:
               mountPath: /var/run/apache2
             - name: barbican-apache-sites
               mountPath: /etc/apache2/sites-enabled
+            - name: barbican-apache-log
+              mountPath: /var/log/apache2
             - name: barbican-bin
               mountPath: /scripts
             {{- if .Values.watcher.enabled }}
@@ -293,6 +295,8 @@ spec:
         - name: barbican-apache-run
           emptyDir: {}
         - name: barbican-apache-sites
+          emptyDir: {}
+        - name: barbican-apache-log
           emptyDir: {}
         - name: barbican-bin
           configMap:

--- a/openstack/barbican/templates/etc/_wsgi-barbican.conf.tpl
+++ b/openstack/barbican/templates/etc/_wsgi-barbican.conf.tpl
@@ -1,4 +1,5 @@
 {{- define "wsgi_barbican_conf" }}
+ServerName {{ include "barbican_api_endpoint_host_public" . }}
 {{- if .Values.use_json }}
 ErrorLog /dev/stdout
 ErrorLogFormat "%M"


### PR DESCRIPTION
Follow-up to #12554 — fixes Apache startup errors observed after deployment.

## Changes

- Add `emptyDir` for `/var/log/apache2` — Apache's `other-vhosts-access-log.conf` tries to open `/var/log/apache2/other_vhosts_access.log` at startup; fails with read-only filesystem error
- Add global `ServerName` directive — suppresses `Could not reliably determine the server's fully qualified domain name` warning at startup

## Root cause

Both errors only appear at runtime with `readOnlyRootFilesystem: true` (restored in #12554). The log directory and FQDN warning were not caught in pre-deploy template validation.
