### PR TITLE
feat(cc-gardener): add shoot-networking-problemdetector extension

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.17
+version: 0.38.18
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/templates/extension-networking-problemdetector.yaml
+++ b/global/cc-gardener/templates/extension-networking-problemdetector.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.extensions.networkingProblemDetector.enabled -}}
+{{- with .Values.extensions.networkingProblemDetector -}}
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: shoot-networking-problemdetector
+spec:
+  resources:
+  - kind: Extension
+    type: shoot-networking-problemdetector
+    {{- if .autoEnable }}
+    autoEnable:
+    {{- range .autoEnable }}
+    - {{ . }}
+    {{- end }}
+    {{- end }}
+  deployment:
+    extension:
+      values:
+{{ include "cc-gardener.extension.mergeValues" (dict "values" .values "extensionContext" . "fallbackTag" .version) | indent 8 }}
+      helm:
+        ociRepository:
+{{ include "cc-gardener.extension.ociRepository" (dict "ociRepository" .helm.ociRepository "fallbackTag" .version) | indent 10 }}
+      policy: OnDemand
+{{- end }}
+{{- end }}

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -861,6 +861,22 @@ extensions:
       ociRepository:
         # tag:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/charts/gardener/extensions/auditing
+  networkingProblemDetector:
+    # Deploys the shoot-networking-problemdetector extension which automatically creates:
+    # - nwpd-agent DaemonSets on shoot nodes (pod-net + node-net checks)
+    # - ScrapeConfig (label: prometheus=shoot) for nwpd_* metrics
+    # - Plutono dashboard ConfigMap (label: dashboard.monitoring.gardener.cloud/shoot=true)
+    # Source: https://github.com/gardener/gardener-extension-shoot-networking-problemdetector
+    enabled: false
+    version: v0.32.1
+    autoEnable:
+    - shoot
+    values:
+      image:
+        repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/shoot-networking-problemdetector
+    helm:
+      ociRepository:
+        repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/charts/gardener/extensions/shoot-networking-problemdetector
 gardenlet:
   enabled: false
   image:


### PR DESCRIPTION
Adds the shoot-networking-problemdetector Gardener extension to cc-gardener.

## Changes
- New template `extension-networking-problemdetector.yaml` — Extension CR with `autoEnable: [shoot]`
- `values.yaml` — adds `extensions.networkingProblemDetector` defaults (disabled by default)
- `Chart.yaml` — bump to 0.38.16

## Behaviour
When enabled per prt-* cluster in kube-secrets, the extension is installed on the operator and automatically rolled out to all shoots via `autoEnable: [shoot]`.

## Testing
Verified on prt-q-eu-de-1 — all managed seeds and end-customer shoots carry label `extensions.extensions.gardener.cloud/shoot-networking-problemdetector=true`.