### PR TITLE
chore(prometheus-operator): upgrade prometheus-operator CRDs to v0.93.0

### DIFF
--- a/system/prometheus-crds/Chart.yaml
+++ b/system/prometheus-crds/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: prometheus-crds
 description: A Helm chart containing Prometheus CRDs.
 type: application
-version: 9.0.0
+version: 10.0.0

--- a/system/prometheus-crds/crds/alertmanagerconfigs.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/alertmanagerconfigs.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -705,7 +705,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -1683,7 +1683,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -2378,7 +2378,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -3141,7 +3141,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -3916,7 +3916,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -4689,7 +4689,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -5541,7 +5541,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -6453,7 +6453,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -6727,6 +6727,12 @@ spec:
                             titleLink:
                               description: titleLink defines the URL that the title will link to when clicked.
                               type: string
+                            updateMessage:
+                              description: |-
+                                updateMessage enables updating existing Slack messages instead of creating new ones
+                                when alert state changes. Please note that Webhook URLs do not support updates.
+                                It requires Alertmanager >= v0.32.0.
+                              type: boolean
                             username:
                               description: username defines the slack bot user name.
                               minLength: 1
@@ -7183,7 +7189,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -7500,6 +7506,14 @@ spec:
                                 If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
                               minLength: 1
                               type: string
+                            useAWSHTTPClient:
+                              description: |-
+                                useAWSHTTPClient forces the AWS SDK's BuildableClient instead of
+                                alertmanager's tracing-wrapped HTTP client. Auto-enabled when AWS_CA_BUNDLE
+                                is set; set explicitly when configuring ca_bundle via shared AWS config.
+
+                                It requires Alertmanager >= 0.33.0.
+                              type: boolean
                           type: object
                         type: array
                         x-kubernetes-list-type: atomic
@@ -7990,7 +8004,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -8725,7 +8739,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -9405,7 +9419,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -10064,7 +10078,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId
@@ -10278,6 +10292,14 @@ spec:
                               format: int32
                               minimum: 0
                               type: integer
+                            payload:
+                              description: |-
+                                payload define custom payload to be sent to the webhook endpoint.
+                                This is an advanced configuration option that allows you
+                                to define a custom payload using Go templates.
+                                It requires Alertmanager >= v0.32.0.
+                              minLength: 1
+                              type: string
                             sendResolved:
                               description: sendResolved defines whether or not to notify about resolved alerts.
                               type: boolean
@@ -10802,7 +10824,7 @@ spec:
                                       type: object
                                     tokenUrl:
                                       description: tokenUrl defines the URL to fetch the token from.
-                                      minLength: 1
+                                      pattern: ^(http|https)://.+$
                                       type: string
                                   required:
                                     - clientId

--- a/system/prometheus-crds/crds/alertmanagers.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/alertmanagers.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: alertmanagers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1539,7 +1539,7 @@ spec:
                                   type: object
                                 tokenUrl:
                                   description: tokenUrl defines the URL to fetch the token from.
-                                  minLength: 1
+                                  pattern: ^(http|https)://.+$
                                   type: string
                               required:
                                 - clientId
@@ -3790,7 +3790,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -5429,7 +5428,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -8174,7 +8172,7 @@ spec:
                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          The volume will be mounted read-only (ro).
                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                         properties:
@@ -8342,8 +8340,7 @@ spec:
                         description: |-
                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                          is on.
+                          are redirected to the pxd.portworx.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -9122,6 +9119,7 @@ spec:
                         getConcurrency defines the maximum number of GET requests processed concurrently. This corresponds to the
                         Alertmanager's `--web.get-concurrency` flag.
                       format: int32
+                      minimum: 0
                       type: integer
                     httpConfig:
                       description: httpConfig defines HTTP parameters for web server.
@@ -9181,6 +9179,7 @@ spec:
                         timeout for HTTP requests. This corresponds to the Alertmanager's
                         `--web.timeout` flag.
                       format: int32
+                      minimum: 0
                       type: integer
                     tlsConfig:
                       description: tlsConfig defines the TLS parameters for HTTPS.

--- a/system/prometheus-crds/crds/podmonitors.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/podmonitors.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -66,6 +66,10 @@ spec:
 
                         The Prometheus service account must have the `list` and `watch`
                         permissions on the `Nodes` objects.
+
+                        Node metadata labels are not automatically added to scraped metrics. They are
+                        exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                        with relabeling configuration.
                       type: boolean
                   type: object
                 bodySizeLimit:
@@ -113,6 +117,7 @@ spec:
 
                     It requires Prometheus >= v2.47.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelLimit:
                   description: |-
@@ -120,6 +125,7 @@ spec:
 
                     It requires Prometheus >= v2.27.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelNameLengthLimit:
                   description: |-
@@ -127,6 +133,7 @@ spec:
 
                     It requires Prometheus >= v2.27.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelValueLengthLimit:
                   description: |-
@@ -134,6 +141,7 @@ spec:
 
                     It requires Prometheus >= v2.27.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 namespaceSelector:
                   description: |-
@@ -157,6 +165,7 @@ spec:
                     buckets will be merged to stay within the limit.
                     It requires Prometheus >= v2.45.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 nativeHistogramMinBucketFactor:
                   anyOf:
@@ -383,6 +392,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -726,7 +736,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -875,6 +885,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -1111,6 +1122,7 @@ spec:
                     sampleLimit defines a per-scrape limit on the number of scraped samples
                     that will be accepted.
                   format: int64
+                  minimum: 0
                   type: integer
                 scrapeClass:
                   description: scrapeClass defines the scrape class to apply.
@@ -1215,6 +1227,7 @@ spec:
                     targetLimit defines a limit on the number of scraped targets that will
                     be accepted.
                   format: int64
+                  minimum: 0
                   type: integer
               required:
                 - selector

--- a/system/prometheus-crds/crds/probes.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/probes.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -216,24 +216,28 @@ spec:
 
                     It requires Prometheus >= v2.47.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelLimit:
                   description: |-
                     labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
                     Only valid in Prometheus versions 2.27.0 and newer.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelNameLengthLimit:
                   description: |-
                     labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
                     Only valid in Prometheus versions 2.27.0 and newer.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelValueLengthLimit:
                   description: |-
                     labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
                     Only valid in Prometheus versions 2.27.0 and newer.
                   format: int64
+                  minimum: 0
                   type: integer
                 metricRelabelings:
                   description: metricRelabelings defines the RelabelConfig to apply to samples before ingestion.
@@ -283,6 +287,7 @@ spec:
 
                           Only applicable when the action is `HashMod`.
                         format: int64
+                        minimum: 0
                         type: integer
                       regex:
                         description: regex defines the regular expression against which the extracted value is matched.
@@ -332,6 +337,7 @@ spec:
                     buckets will be merged to stay within the limit.
                     It requires Prometheus >= v2.45.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 nativeHistogramMinBucketFactor:
                   anyOf:
@@ -641,7 +647,7 @@ spec:
                       type: object
                     tokenUrl:
                       description: tokenUrl defines the URL to fetch the token from.
-                      minLength: 1
+                      pattern: ^(http|https)://.+$
                       type: string
                   required:
                     - clientId
@@ -759,6 +765,7 @@ spec:
                 sampleLimit:
                   description: sampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
                   format: int64
+                  minimum: 0
                   type: integer
                 scrapeClass:
                   description: scrapeClass defines the scrape class to apply.
@@ -812,6 +819,7 @@ spec:
                 targetLimit:
                   description: targetLimit defines a limit on the number of scraped targets that will be accepted.
                   format: int64
+                  minimum: 0
                   type: integer
                 targets:
                   description: targets defines a set of static or dynamically discovered targets to probe.
@@ -891,6 +899,7 @@ spec:
 
                                   Only applicable when the action is `HashMod`.
                                 format: int64
+                                minimum: 0
                                 type: integer
                               regex:
                                 description: regex defines the regular expression against which the extracted value is matched.
@@ -1036,6 +1045,7 @@ spec:
 
                                   Only applicable when the action is `HashMod`.
                                 format: int64
+                                minimum: 0
                                 type: integer
                               regex:
                                 description: regex defines the regular expression against which the extracted value is matched.

--- a/system/prometheus-crds/crds/prometheusagents.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/prometheusagents.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: prometheusagents.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -2461,7 +2461,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -2999,6 +2998,7 @@ spec:
                     * Scrape objects with a keepDroppedTargets value less than or equal to enforcedKeepDroppedTargets keep their specific value.
                     * Scrape objects with a keepDroppedTargets value greater than enforcedKeepDroppedTargets are set to enforcedKeepDroppedTargets.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedLabelLimit:
                   description: |-
@@ -3015,6 +3015,7 @@ spec:
                     * Scrape objects with a labelLimit value less than or equal to enforcedLabelLimit keep their specific value.
                     * Scrape objects with a labelLimit value greater than enforcedLabelLimit are set to enforcedLabelLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedLabelNameLengthLimit:
                   description: |-
@@ -3031,6 +3032,7 @@ spec:
                     * Scrape objects with a labelNameLengthLimit value less than or equal to enforcedLabelNameLengthLimit keep their specific value.
                     * Scrape objects with a labelNameLengthLimit value greater than enforcedLabelNameLengthLimit are set to enforcedLabelNameLengthLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedLabelValueLengthLimit:
                   description: |-
@@ -3047,6 +3049,7 @@ spec:
                     * Scrape objects with a labelValueLengthLimit value less than or equal to enforcedLabelValueLengthLimit keep their specific value.
                     * Scrape objects with a labelValueLengthLimit value greater than enforcedLabelValueLengthLimit are set to enforcedLabelValueLengthLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedNamespaceLabel:
                   description: |-
@@ -3080,6 +3083,7 @@ spec:
                     * Scrape objects with a sampleLimit value less than or equal to enforcedSampleLimit keep their specific value.
                     * Scrape objects with a sampleLimit value greater than enforcedSampleLimit are set to enforcedSampleLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedTargetLimit:
                   description: |-
@@ -3097,6 +3101,7 @@ spec:
                     * Scrape objects with a targetLimit value less than or equal to enforcedTargetLimit keep their specific value.
                     * Scrape objects with a targetLimit value greater than enforcedTargetLimit are set to enforcedTargetLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 excludedFromEnforcement:
                   description: |-
@@ -4318,7 +4323,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -4736,6 +4740,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedKeepDroppedTargets.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelLimit:
                   description: |-
@@ -4745,6 +4750,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedLabelLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelNameLengthLimit:
                   description: |-
@@ -4754,6 +4760,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedLabelNameLengthLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelValueLengthLimit:
                   description: |-
@@ -4763,6 +4770,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedLabelValueLengthLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 listenLocal:
                   description: |-
@@ -4865,6 +4873,26 @@ spec:
                         resource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.
 
                         It requires Prometheus >= v3.1.0.
+                      type: boolean
+                    labelNamePreserveMultipleUnderscores:
+                      description: |-
+                        labelNamePreserveMultipleUnderscores enables preserving of multiple consecutive underscores in label names when translation_strategy uses
+                        underscore escaping.
+                        When true (default), multiple consecutive underscores are preserved during label name sanitization.
+
+                        Notice: This one has no impact if `nameEscapingScheme` is `AllowUTF8`.
+
+                        It requires Prometheus >= v3.8.0.
+                      type: boolean
+                    labelNameUnderscoreSanitization:
+                      description: |-
+                        labelNameUnderscoreSanitization controls whether to enable prepending of 'key_' to labels starting with '_'.
+                        Reserved labels starting with '__' are not modified.
+                        This is only relevant when translation_strategy uses underscore escaping (e.g., "UnderscoreEscapingWithSuffixes" or "UnderscoreEscapingWithoutSuffixes").
+
+                        Notice: This one has no impact if `nameEscapingScheme` is `AllowUTF8`.
+
+                        It requires Prometheus >= v3.8.0.
                       type: boolean
                     promoteAllResourceAttributes:
                       description: |-
@@ -5514,7 +5542,10 @@ spec:
                             minimum: -1
                             type: integer
                           send:
-                            description: send defines whether metric metadata is sent to the remote storage or not.
+                            description: |-
+                              send defines whether metric metadata is sent to the remote storage or not.
+
+                              The setting is ignored when Remote Write message's version 2.0 is used.
                             type: boolean
                           sendInterval:
                             description: sendInterval defines how frequently metric metadata is sent to the remote storage.
@@ -5834,7 +5865,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -6245,6 +6276,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -6404,6 +6436,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedSampleLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 schedulerName:
                   description: schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.
@@ -6431,6 +6464,10 @@ spec:
 
                               The Prometheus service account must have the `list` and `watch`
                               permissions on the `Nodes` objects.
+
+                              Node metadata labels are not automatically added to scraped metrics. They are
+                              exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                              with relabeling configuration.
                             type: boolean
                         type: object
                       authorization:
@@ -6547,6 +6584,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -6644,6 +6682,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -7443,6 +7482,7 @@ spec:
                     - message: topology can only be defined when mode is set to 'Topology'
                       rule: '!has(self.topology) || (has(self.mode) && self.mode == ''Topology'')'
                 shards:
+                  default: 1
                   description: |-
                     shards defines the number of shards to distribute the scraped targets onto.
 
@@ -7470,6 +7510,8 @@ spec:
                     You can also disable sharding on a specific target by setting the
                     `__tmp_disable_sharding` label with relabeling configuration. When
                     the label value isn't empty, all Prometheus shards will scrape the target.
+
+                    Default: 1
                   format: int32
                   type: integer
                 storage:
@@ -8101,6 +8143,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedTargetLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 terminationGracePeriodSeconds:
                   description: |-
@@ -8539,6 +8582,31 @@ spec:
                     tsdb defines the runtime reloadable configuration of the timeseries database(TSDB).
                     It requires Prometheus >= v2.39.0 or PrometheusAgent >= v2.54.0.
                   properties:
+                    chunkEncoding:
+                      description: |-
+                        chunkEncoding configures per-chunk-type encoding overrides.
+
+                        It requires Prometheus >= v3.13.0.
+
+                        Notice: Setting "Xor" is incompatible with --enable-feature=st-storage
+                        (XOR chunks do not store start timestamps).
+                      properties:
+                        floats:
+                          description: |-
+                            floats selects the encoding used for float chunks.
+                            Valid values are "Xor" and "Xor2".
+
+                            Notice:
+                             * Setting "Xor" is incompatible with --enable-feature=st-storage
+                            (XOR chunks do not store start timestamps).
+                             * Setting "Xor2" automatically adds the `xor2-encoding` feature flag.
+
+                            It requires Prometheus >= v3.13.0.
+                          enum:
+                            - Xor
+                            - Xor2
+                          type: string
+                      type: object
                     outOfOrderTimeWindow:
                       description: |-
                         outOfOrderTimeWindow defines how old an out-of-order/out-of-bounds sample can be with
@@ -8553,6 +8621,26 @@ spec:
                         It requires Prometheus >= v2.39.0 or PrometheusAgent >= v2.54.0.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
+                    staleSeriesCompactionThreshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        staleSeriesCompactionThreshold configures the trigger point for compacting
+                        stale series from memory into persistent blocks and removing those stale
+                        series from memory.
+
+                        The threshold is a number between 0.0 and 1.0. It represents the ratio of
+                        stale series in memory to the total series in memory. The stale series
+                        compaction is triggered when this ratio crosses the configured threshold.
+                        It may not trigger the stale series compaction if the usual head compaction
+                        is about to happen soon.
+
+                        If set to 0, stale series compaction is disabled.
+
+                        It requires Prometheus >= v3.10.0.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                   type: object
                 updateStrategy:
                   description: |-
@@ -9550,7 +9638,7 @@ spec:
                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          The volume will be mounted read-only (ro).
                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                         properties:
@@ -9718,8 +9806,7 @@ spec:
                         description: |-
                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                          is on.
+                          are redirected to the pxd.portworx.com CSI driver.
                         properties:
                           fsType:
                             description: |-

--- a/system/prometheus-crds/crds/prometheuses.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/prometheuses.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1144,6 +1144,7 @@ spec:
 
                                     Only applicable when the action is `HashMod`.
                                   format: int64
+                                  minimum: 0
                                   type: integer
                                 regex:
                                   description: regex defines the regular expression against which the extracted value is matched.
@@ -1415,6 +1416,7 @@ spec:
 
                                     Only applicable when the action is `HashMod`.
                                   format: int64
+                                  minimum: 0
                                   type: integer
                                 regex:
                                   description: regex defines the regular expression against which the extracted value is matched.
@@ -3174,7 +3176,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -3592,8 +3593,15 @@ spec:
                 disableCompaction:
                   description: |-
                     disableCompaction when true, the Prometheus compaction is disabled.
-                    When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
-                    disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
+
+                    When `spec.thanos.objectStorageConfig` or `spec.thanos.objectStorageConfigFile` are defined, the operator's
+                    default handling depends on the Prometheus and Thanos sidecar versions:
+                      - With Prometheus < v3.9.0 or a Thanos sidecar < v0.41.0, block compaction is disabled to avoid race
+                        conditions during block uploads (as the Thanos documentation recommends).
+                      - With Prometheus >= v3.9.0 and a Thanos sidecar >= v0.41.0, local compaction is kept enabled and coordinated
+                        with the sidecar through the shipper meta file (`--storage.tsdb.delay-compact-file.path`), so blocks are only
+                        compacted after they have been uploaded.
+                    Setting this field to true always disables local compaction regardless of the versions.
                   type: boolean
                 dnsConfig:
                   description: dnsConfig defines the DNS configuration for the pods.
@@ -3730,6 +3738,7 @@ spec:
                     * Scrape objects with a keepDroppedTargets value less than or equal to enforcedKeepDroppedTargets keep their specific value.
                     * Scrape objects with a keepDroppedTargets value greater than enforcedKeepDroppedTargets are set to enforcedKeepDroppedTargets.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedLabelLimit:
                   description: |-
@@ -3746,6 +3755,7 @@ spec:
                     * Scrape objects with a labelLimit value less than or equal to enforcedLabelLimit keep their specific value.
                     * Scrape objects with a labelLimit value greater than enforcedLabelLimit are set to enforcedLabelLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedLabelNameLengthLimit:
                   description: |-
@@ -3762,6 +3772,7 @@ spec:
                     * Scrape objects with a labelNameLengthLimit value less than or equal to enforcedLabelNameLengthLimit keep their specific value.
                     * Scrape objects with a labelNameLengthLimit value greater than enforcedLabelNameLengthLimit are set to enforcedLabelNameLengthLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedLabelValueLengthLimit:
                   description: |-
@@ -3778,6 +3789,7 @@ spec:
                     * Scrape objects with a labelValueLengthLimit value less than or equal to enforcedLabelValueLengthLimit keep their specific value.
                     * Scrape objects with a labelValueLengthLimit value greater than enforcedLabelValueLengthLimit are set to enforcedLabelValueLengthLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedNamespaceLabel:
                   description: |-
@@ -3811,6 +3823,7 @@ spec:
                     * Scrape objects with a sampleLimit value less than or equal to enforcedSampleLimit keep their specific value.
                     * Scrape objects with a sampleLimit value greater than enforcedSampleLimit are set to enforcedSampleLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 enforcedTargetLimit:
                   description: |-
@@ -3828,6 +3841,7 @@ spec:
                     * Scrape objects with a targetLimit value less than or equal to enforcedTargetLimit keep their specific value.
                     * Scrape objects with a targetLimit value greater than enforcedTargetLimit are set to enforcedTargetLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 evaluationInterval:
                   default: 30s
@@ -5073,7 +5087,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -5491,6 +5504,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedKeepDroppedTargets.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelLimit:
                   description: |-
@@ -5500,6 +5514,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedLabelLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelNameLengthLimit:
                   description: |-
@@ -5509,6 +5524,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedLabelNameLengthLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelValueLengthLimit:
                   description: |-
@@ -5518,6 +5534,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedLabelValueLengthLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 listenLocal:
                   description: |-
@@ -5611,6 +5628,26 @@ spec:
                         resource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.
 
                         It requires Prometheus >= v3.1.0.
+                      type: boolean
+                    labelNamePreserveMultipleUnderscores:
+                      description: |-
+                        labelNamePreserveMultipleUnderscores enables preserving of multiple consecutive underscores in label names when translation_strategy uses
+                        underscore escaping.
+                        When true (default), multiple consecutive underscores are preserved during label name sanitization.
+
+                        Notice: This one has no impact if `nameEscapingScheme` is `AllowUTF8`.
+
+                        It requires Prometheus >= v3.8.0.
+                      type: boolean
+                    labelNameUnderscoreSanitization:
+                      description: |-
+                        labelNameUnderscoreSanitization controls whether to enable prepending of 'key_' to labels starting with '_'.
+                        Reserved labels starting with '__' are not modified.
+                        This is only relevant when translation_strategy uses underscore escaping (e.g., "UnderscoreEscapingWithSuffixes" or "UnderscoreEscapingWithoutSuffixes").
+
+                        Notice: This one has no impact if `nameEscapingScheme` is `AllowUTF8`.
+
+                        It requires Prometheus >= v3.8.0.
                       type: boolean
                     promoteAllResourceAttributes:
                       description: |-
@@ -6492,7 +6529,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -6717,7 +6754,11 @@ spec:
                             type: string
                         type: object
                       url:
-                        description: url defines the URL of the endpoint to query from.
+                        description: |-
+                          url defines the URL of the endpoint to query from.
+
+                          It must use the HTTP or HTTPS scheme.
+                        pattern: ^(http|https)://.+$
                         type: string
                     required:
                       - url
@@ -7001,7 +7042,10 @@ spec:
                             minimum: -1
                             type: integer
                           send:
-                            description: send defines whether metric metadata is sent to the remote storage or not.
+                            description: |-
+                              send defines whether metric metadata is sent to the remote storage or not.
+
+                              The setting is ignored when Remote Write message's version 2.0 is used.
                             type: boolean
                           sendInterval:
                             description: sendInterval defines how frequently metric metadata is sent to the remote storage.
@@ -7321,7 +7365,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -7732,6 +7776,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -8030,6 +8075,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedSampleLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 schedulerName:
                   description: schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.
@@ -8057,6 +8103,10 @@ spec:
 
                               The Prometheus service account must have the `list` and `watch`
                               permissions on the `Nodes` objects.
+
+                              Node metadata labels are not automatically added to scraped metrics. They are
+                              exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                              with relabeling configuration.
                             type: boolean
                         type: object
                       authorization:
@@ -8173,6 +8223,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -8270,6 +8321,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -9026,11 +9078,8 @@ spec:
                 shardRetentionPolicy:
                   description: |-
                     shardRetentionPolicy defines the retention policy for the Prometheus shards.
-                    (Alpha) Using this field requires the 'PrometheusShardRetentionPolicy' feature gate to be enabled.
 
-                    The final goals for this feature can be seen at https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers,
-                    however, the feature is not yet fully implemented in this PR. The limitation being:
-                    * Retention duration is not settable, for now, shards are retained forever.
+                    (Beta) Using this mode requires the `PrometheusShardRetentionPolicy` feature gate (enabled by default).
                   properties:
                     retain:
                       description: |-
@@ -9111,6 +9160,7 @@ spec:
                     - message: topology can only be defined when mode is set to 'Topology'
                       rule: '!has(self.topology) || (has(self.mode) && self.mode == ''Topology'')'
                 shards:
+                  default: 1
                   description: |-
                     shards defines the number of shards to distribute the scraped targets onto.
 
@@ -9138,6 +9188,8 @@ spec:
                     You can also disable sharding on a specific target by setting the
                     `__tmp_disable_sharding` label with relabeling configuration. When
                     the label value isn't empty, all Prometheus shards will scrape the target.
+
+                    Default: 1
                   format: int32
                   type: integer
                 storage:
@@ -9772,6 +9824,7 @@ spec:
                     Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedTargetLimit.
                   format: int64
+                  minimum: 0
                   type: integer
                 terminationGracePeriodSeconds:
                   description: |-
@@ -10729,6 +10782,31 @@ spec:
                     tsdb defines the runtime reloadable configuration of the timeseries database(TSDB).
                     It requires Prometheus >= v2.39.0 or PrometheusAgent >= v2.54.0.
                   properties:
+                    chunkEncoding:
+                      description: |-
+                        chunkEncoding configures per-chunk-type encoding overrides.
+
+                        It requires Prometheus >= v3.13.0.
+
+                        Notice: Setting "Xor" is incompatible with --enable-feature=st-storage
+                        (XOR chunks do not store start timestamps).
+                      properties:
+                        floats:
+                          description: |-
+                            floats selects the encoding used for float chunks.
+                            Valid values are "Xor" and "Xor2".
+
+                            Notice:
+                             * Setting "Xor" is incompatible with --enable-feature=st-storage
+                            (XOR chunks do not store start timestamps).
+                             * Setting "Xor2" automatically adds the `xor2-encoding` feature flag.
+
+                            It requires Prometheus >= v3.13.0.
+                          enum:
+                            - Xor
+                            - Xor2
+                          type: string
+                      type: object
                     outOfOrderTimeWindow:
                       description: |-
                         outOfOrderTimeWindow defines how old an out-of-order/out-of-bounds sample can be with
@@ -10743,6 +10821,26 @@ spec:
                         It requires Prometheus >= v2.39.0 or PrometheusAgent >= v2.54.0.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
+                    staleSeriesCompactionThreshold:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        staleSeriesCompactionThreshold configures the trigger point for compacting
+                        stale series from memory into persistent blocks and removing those stale
+                        series from memory.
+
+                        The threshold is a number between 0.0 and 1.0. It represents the ratio of
+                        stale series in memory to the total series in memory. The stale series
+                        compaction is triggered when this ratio crosses the configured threshold.
+                        It may not trigger the stale series compaction if the usual head compaction
+                        is about to happen soon.
+
+                        If set to 0, stale series compaction is disabled.
+
+                        It requires Prometheus >= v3.10.0.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                   type: object
                 updateStrategy:
                   description: |-
@@ -11740,7 +11838,7 @@ spec:
                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          The volume will be mounted read-only (ro).
                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                         properties:
@@ -11908,8 +12006,7 @@ spec:
                         description: |-
                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                          is on.
+                          are redirected to the pxd.portworx.com CSI driver.
                         properties:
                           fsType:
                             description: |-

--- a/system/prometheus-crds/crds/prometheusrules.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/prometheusrules.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/system/prometheus-crds/crds/scrapeconfigs.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/scrapeconfigs.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -527,7 +527,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -1264,7 +1264,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -1894,7 +1894,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -2598,7 +2598,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -3252,7 +3252,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -4213,7 +4213,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -4933,7 +4933,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -5573,7 +5573,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -6140,7 +6140,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -6372,6 +6372,7 @@ spec:
 
                     It requires Prometheus >= v2.47.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 kubernetesSDConfigs:
                   description: kubernetesSDConfigs defines a list of Kubernetes service discovery configurations.
@@ -6817,7 +6818,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -7482,7 +7483,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -7700,18 +7701,21 @@ spec:
                     labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
                     Only valid in Prometheus versions 2.27.0 and newer.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelNameLengthLimit:
                   description: |-
                     labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
                     Only valid in Prometheus versions 2.27.0 and newer.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelValueLengthLimit:
                   description: |-
                     labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
                     Only valid in Prometheus versions 2.27.0 and newer.
                   format: int64
+                  minimum: 0
                   type: integer
                 lightSailSDConfigs:
                   description: lightSailSDConfigs defines a list of Lightsail service discovery configurations.
@@ -8145,7 +8149,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -8740,7 +8744,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -9009,6 +9013,7 @@ spec:
 
                           Only applicable when the action is `HashMod`.
                         format: int64
+                        minimum: 0
                         type: integer
                       regex:
                         description: regex defines the regular expression against which the extracted value is matched.
@@ -9077,6 +9082,7 @@ spec:
                     buckets will be merged to stay within the limit.
                     It requires Prometheus >= v2.45.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 nativeHistogramMinBucketFactor:
                   anyOf:
@@ -9509,7 +9515,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -10029,7 +10035,7 @@ spec:
                       type: object
                     tokenUrl:
                       description: tokenUrl defines the URL to fetch the token from.
-                      minLength: 1
+                      pattern: ^(http|https)://.+$
                       type: string
                   required:
                     - clientId
@@ -10891,7 +10897,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -11169,6 +11175,7 @@ spec:
 
                           Only applicable when the action is `HashMod`.
                         format: int64
+                        minimum: 0
                         type: integer
                       regex:
                         description: regex defines the regular expression against which the extracted value is matched.
@@ -11210,6 +11217,7 @@ spec:
                 sampleLimit:
                   description: sampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
                   format: int64
+                  minimum: 0
                   type: integer
                 scalewaySDConfigs:
                   description: scalewaySDConfigs defines a list of Scaleway instances and baremetal service discovery configurations.
@@ -11592,6 +11600,7 @@ spec:
                 targetLimit:
                   description: targetLimit defines a limit on the number of scraped targets that will be accepted.
                   format: int64
+                  minimum: 0
                   type: integer
                 tlsConfig:
                   description: tlsConfig defines the TLS configuration to use on every scrape request

--- a/system/prometheus-crds/crds/servicemonitors.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/servicemonitors.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -68,6 +68,10 @@ spec:
 
                         The Prometheus service account must have the `list` and `watch`
                         permissions on the `Nodes` objects.
+
+                        Node metadata labels are not automatically added to scraped metrics. They are
+                        exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                        with relabeling configuration.
                       type: boolean
                   type: object
                 bodySizeLimit:
@@ -307,6 +311,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -650,7 +655,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -672,7 +677,8 @@ spec:
                         type: string
                       port:
                         description: |-
-                          port defines the name of the Service port which this endpoint refers to.
+                          port defines the name of the Service port which this endpoint refers to
+                          (e.g. `.spec.ports[].name`).
 
                           It takes precedence over `targetPort`.
                         type: string
@@ -774,6 +780,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -833,8 +840,10 @@ spec:
                           - type: integer
                           - type: string
                         description: |-
-                          targetPort defines the name or number of the target port of the `Pod` object behind the
-                          Service. The port must be specified with the container's port property.
+                          targetPort defines the name or number of a container port on Pods selected
+                          by the Service.
+                          If a name, it matches against `.spec.containers[].ports[].name` of the Pods.
+                          If a number, it matches against `.spec.containers[].ports[].containerPort` of the Pods.
                         x-kubernetes-int-or-string: true
                       tlsConfig:
                         description: tlsConfig defines TLS configuration used by the client.
@@ -1037,6 +1046,7 @@ spec:
 
                     It requires Prometheus >= v2.47.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelLimit:
                   description: |-
@@ -1044,6 +1054,7 @@ spec:
 
                     It requires Prometheus >= v2.27.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelNameLengthLimit:
                   description: |-
@@ -1051,6 +1062,7 @@ spec:
 
                     It requires Prometheus >= v2.27.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 labelValueLengthLimit:
                   description: |-
@@ -1058,6 +1070,7 @@ spec:
 
                     It requires Prometheus >= v2.27.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 namespaceSelector:
                   description: |-
@@ -1081,6 +1094,7 @@ spec:
                     buckets will be merged to stay within the limit.
                     It requires Prometheus >= v2.45.0.
                   format: int64
+                  minimum: 0
                   type: integer
                 nativeHistogramMinBucketFactor:
                   anyOf:
@@ -1104,6 +1118,7 @@ spec:
                     sampleLimit defines a per-scrape limit on the number of scraped samples
                     that will be accepted.
                   format: int64
+                  minimum: 0
                   type: integer
                 scrapeClass:
                   description: scrapeClass defines the scrape class to apply.
@@ -1226,6 +1241,7 @@ spec:
                     targetLimit defines a limit on the number of scraped targets that will
                     be accepted.
                   format: int64
+                  minimum: 0
                   type: integer
               required:
                 - endpoints

--- a/system/prometheus-crds/crds/thanosrulers.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/thanosrulers.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
-    operator.prometheus.io/version: 0.91.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.93.0
   name: thanosrulers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -2143,7 +2143,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -4000,7 +3999,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -4904,7 +4902,10 @@ spec:
                             minimum: -1
                             type: integer
                           send:
-                            description: send defines whether metric metadata is sent to the remote storage or not.
+                            description: |-
+                              send defines whether metric metadata is sent to the remote storage or not.
+
+                              The setting is ignored when Remote Write message's version 2.0 is used.
                             type: boolean
                           sendInterval:
                             description: sendInterval defines how frequently metric metadata is sent to the remote storage.
@@ -5224,7 +5225,7 @@ spec:
                             type: object
                           tokenUrl:
                             description: tokenUrl defines the URL to fetch the token from.
-                            minLength: 1
+                            pattern: ^(http|https)://.+$
                             type: string
                         required:
                           - clientId
@@ -5635,6 +5636,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against which the extracted value is matched.
@@ -8000,7 +8002,7 @@ spec:
                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          The volume will be mounted read-only (ro).
                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                         properties:
@@ -8168,8 +8170,7 @@ spec:
                         description: |-
                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                          is on.
+                          are redirected to the pxd.portworx.com CSI driver.
                         properties:
                           fsType:
                             description: |-


### PR DESCRIPTION
Upgrades the prometheus-operator CRDs from v0.91.0 to v0.93.0 to align with
kube-prometheus-stack 88.2.0 (bumped in #12544).

Changes:
- Fetched all 10 CRDs from the upstream prometheus-operator v0.93.0 release bundle
  via the get-crds script
- Bumped prometheus-crds chart version: 9.0.0 → 10.0.0