### PR TITLE
chore(kube-monitoring/kube-system): bump prometheus-crds to 10.0.0

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -44,5 +44,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:8d39dced61a2ae84bd32004e06ede45ab07ca4785a396eaaa5908cda5cf4e3be
-generated: "2026-07-22T12:31:06.381154+02:00"
+digest: sha256:2bc034469eb6b0fb34d593b9fca6e113a3279b63623c0ce7987460814ae8a8f9
+generated: "2026-08-18T16:42:49.533801+02:00"

--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.1.1
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.8.4
+version: 4.8.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   - condition: prometheus-crds.enabled
     name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 9.0.0
+    version: 10.0.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -53,5 +53,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:2856878311508d4ef6bbf35a65cb8cd7ee86b90182861986bc59840e959368da
-generated: "2026-07-22T12:30:53.2674+02:00"
+digest: sha256:6bf7713878de8fc4912a6005670e538aba10561ab51b43bcfa3027e21fc825a1
+generated: "2026-08-18T16:42:18.312873+02:00"

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 0.1.1
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.10.5
+version: 7.10.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     version: 0.1.1
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 9.0.0
+    version: 10.0.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -47,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:a516fcd145d76241378650627c15c309fb062b9f9ee17983479d5db81a6ae96e
-generated: "2026-07-22T12:30:29.89932+02:00"
+digest: sha256:39f96c36c10ee15067e7dd48595abccf892d7306a98f41d6f97fd11f37606a14
+generated: "2026-08-18T16:42:37.412803+02:00"

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 1.1.0
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.11.5
+version: 4.11.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     version: 1.1.0
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 9.0.0
+    version: 10.0.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -44,5 +44,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:553fce7b3a0ba8f128ea00947417c855a2c0c967e4eabd7f1d3b7bb41748f3f2
-generated: "2026-07-22T12:30:38.317705+02:00"
+digest: sha256:f9cc09e12037979818845f258a07fe436abfa0ad828366a96664e26364fe3c20
+generated: "2026-08-18T16:41:39.100832+02:00"

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.1.4
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
     version: "^1.x"
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: "9.0.0"
+    version: "10.0.0"
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.13.4
+version: 4.13.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -47,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:efe1ad42df59cf840b02c31be7aa5ecf14d0bbd7743d2014ad2aadcf9e7b00d6
-generated: "2026-07-22T12:30:45.253522+02:00"
+digest: sha256:64a0d86e433c1d274d42ca872ac415826effbc54ae272087fa04c8a19ebe5caa
+generated: "2026-08-18T16:42:02.895701+02:00"

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.1.1
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.11.4
+version: 6.11.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     version: 0.1.1
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 9.0.0
+    version: 10.0.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: traefik
   repository: https://helm.traefik.io/traefik
   version: 39.0.5

--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.8.1
+  version: 2.8.2
 - name: priority-class
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.0.0
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:cda32415ea7fde839361add7bc1b34e26e9c734c67e5b99fbe4ba8501f151bf3
-generated: "2026-08-07T11:40:31.781123+02:00"
+digest: sha256:d4065e52b1b82421b0626a8eb67ade8e5108af94d890a3ed1d60347db9afdf99
+generated: "2026-08-18T16:44:08.493758+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: ">= 0.0.0"
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 9.0.0
+    version: 10.0.0
   - name: traefik
     repository: https://helm.traefik.io/traefik
     version: 39.0.5

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.7.9
+version: 3.7.10
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.21.1

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.8.1
+  version: 2.8.2
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server
   version: 3.13.1
@@ -38,5 +38,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:7a81d0d256351fefa44f44cc818af2a21875c3ea114c1d233963c7d4ec57d7e0
-generated: "2026-08-07T11:40:24.709876+02:00"
+digest: sha256:1d31ef70857be397d83624558ab37b39af9e3c227e8d4c7847ff78afb4bfc1d6
+generated: "2026-08-18T16:43:39.271953+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.11.9
+version: 3.11.10
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 9.0.0
+    version: 10.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
     version: 1.21.1

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: sysctl
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.9

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.8.1
+  version: 2.8.2
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.15.1
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:b6afb45d97908b2af669b42dc42ab6c4644bbd4384015520cf9cc14788a0d412
-generated: "2026-08-07T11:40:01.569874+02:00"
+digest: sha256:b54faca4509649dfdea468b768e3e0f76faf4dc3aa2c4bd66c72092d92d4011a
+generated: "2026-08-18T16:43:53.39592+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.13
+version: 6.14.14
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 9.0.0
+    version: 10.0.0
   - name: sysctl
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^0.x"

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.8.1
+  version: 2.8.2
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server
   version: 3.13.1
@@ -44,5 +44,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:ba8bfc906ce25da70c8c6f027c652c247d844e3ddad74e3f7b644648f755a15a
-generated: "2026-08-07T11:40:10.638024+02:00"
+digest: sha256:d157d36cf45776924cb5d7512bb1ef7ba3c42d0c277db9007b8ee4bf1e7d10a8
+generated: "2026-08-18T16:43:11.144232+02:00"

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.21.1

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 9.0.0
+    version: 10.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
     version: 1.21.1

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.9
+version: 5.13.10
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: wormhole
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 3.1.8

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -28,7 +28,7 @@ dependencies:
   version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.8.1
+  version: 2.8.2
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -56,5 +56,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:eb652edd64bdb7f526cad5be100421a295846f4a9721f6e2c9dbe7322f57781b
-generated: "2026-08-07T11:40:17.40573+02:00"
+digest: sha256:980440afc759cba4f7f0cd119da4d6ef451a394afa17f9f251dfabe4b5c09f1c
+generated: "2026-08-18T16:43:24.931975+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 9.0.0
+    version: 10.0.0
   - name: wormhole
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.12
+version: 4.9.13
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac


### PR DESCRIPTION
Follow-up to #12596: bumps the prometheus-crds dependency from 9.0.0 → 10.0.0
across all consumer charts so they pick up the CRDs for prometheus-operator v0.93.0.