### PR TITLE
chore(prometheus-operator): bump prometheus-crds to 10.0.0

### DIFF
--- a/system/prometheus-operator/Chart.lock
+++ b/system/prometheus-operator/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 10.0.0
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 88.2.0
+  version: 88.3.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:0f1fba2b46f3ca1dd359882198f6aefbd468f3c43da6a396b991f7d59eb1fdec
-generated: "2026-08-11T11:06:28.792164+02:00"
+digest: sha256:7ca648734b3d003a5dae69fb5b8e4a9a82a1c24f6d95a2d9d44c8a2886fb5bd3
+generated: "2026-08-18T16:41:01.172841+02:00"

--- a/system/prometheus-operator/Chart.lock
+++ b/system/prometheus-operator/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 9.0.0
+  version: 10.0.0
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 88.2.0

--- a/system/prometheus-operator/Chart.yaml
+++ b/system/prometheus-operator/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     # please update kube-monitoring-* and kube-system-* crds too, otherwise they will overwrite this
-    version: 9.0.0
+    version: 10.0.0
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
     version: '>= 0.0.0'


### PR DESCRIPTION
Follow-up to #12596: bumps the prometheus-crds dependency from 9.0.0 → 10.0.0 to pick up the CRDs for prometheus-operator v0.93.0.