### PR TITLE
[nova][cross-hv] Add default vol type for adopted eph disks

### DIFF
--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -33,6 +33,9 @@ data:
 {{- $configErrorMsg := printf "'.Values.%[1]s.conductor.config_file' is required for cell '%[1]s'" $cellId }}
 {{- $cellValues := get $envAll.Values $cellId | required $configErrorMsg }}
 {{- $conductorConfig := $cellValues.conductor.config_file | required $configErrorMsg }}
+{{- if hasKey $envAll.Values.conductor.config_file "cross_hv" }}
+{{- $_ := set $conductorConfig "cross_hv" $envAll.Values.conductor.config_file.cross_hv }}
+{{- end }}
   nova-{{ $cellName }}-conductor.conf: |
 {{ include "util.helpers.valuesToIni" $conductorConfig | indent 4 }}
 {{- end }}


### PR DESCRIPTION
The on eph-root-disk-VM migration to KVM, the conductor instructs cinder to adopt the root disk VMDK as a proper FCD cinder volume. This needs a volume type set.

Expect this setting in regional nova secrets config object in

    conductor.config_file.cross_hv

with the contained sub-key 'fcd_volume_type'.
The conductor has per-cell config, but this is a regional setting, so we propagate this into all per-cell-conductor configs.

Default to type "vmware".
