### PR TITLE
cinder: allow service requests to manage volumes

### DIFF
--- a/openstack/cinder/templates/etc/_cinder-policy.yaml.tpl
+++ b/openstack/cinder/templates/etc/_cinder-policy.yaml.tpl
@@ -84,7 +84,7 @@
 "volume_extension:services:index": "rule:context_is_admin"
 "volume_extension:services:update": "rule:context_is_admin"
 
-"volume_extension:volume_manage": "rule:context_is_admin"
+"volume_extension:volume_manage": "rule:context_is_admin or is_service_request:True"
 "volume_extension:volume_unmanage": "rule:context_is_admin"
 
 "volume_extension:capabilities": "rule:context_is_admin"


### PR DESCRIPTION
This allows e.g. nova to performm `cinder manage` operations on behalf of a non-admin user.