### PR TITLE
[opensearch-logs] reduce min_primary_shard_size to 40gb

### DIFF
--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the Opensearch stack
 name: opensearch-logs
-version: 0.1.33
+version: 0.1.34
 home: https://github.com/sapcc/helm-charts/tree/master/system/opensearch-logs
 dependencies:
   - name: opensearch

--- a/system/opensearch-logs/values.yaml
+++ b/system/opensearch-logs/values.yaml
@@ -43,7 +43,7 @@ global:
     storage:
       min_index_age: "7d"
       max_index_age: "14d"
-      min_size: "80gb"
+      min_size: "40gb"
       min_doc_count: 100000000
       number_of_shards: 4
       refresh_interval: "120s"
@@ -56,7 +56,7 @@ global:
         retention: "31d"
     compute:
       min_index_age: "7d"
-      min_size: "80gb"
+      min_size: "40gb"
       min_doc_count: 100000000
     cronus:
       min_index_age: "7d"
@@ -91,7 +91,7 @@ global:
         retention: "31d"
     logs_swift:
       min_index_age: "14d"
-      min_size: "120gb"
+      min_size: "40gb"
       min_doc_count: 200000000
       snapshots:
         enabled: false
@@ -102,7 +102,7 @@ global:
         retention: "31d"
     jump:
       min_index_age: "7d"
-      min_size: "80gb"
+      min_size: "40gb"
       min_doc_count: 100000000
   index:
     ism_indexes: "logstash"


### PR DESCRIPTION
- Set min_primary_shard_size to 40gb for storage, compute, logs_swift, and jump datastreams
- 40gb per single primary shard is the recommended shard size for OpenSearch
