### PR TITLE
pers: fix value scoping for dashboard cert w/ domain override

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.17
+version: 0.38.18
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/templates/gardener-dashboard-cert.yaml
+++ b/global/cc-gardener/templates/gardener-dashboard-cert.yaml
@@ -8,8 +8,8 @@ spec:
   secretName: gardener-certificate-secret
   dnsNames:
 {{- if .Values.garden.domainOverride }}
-  - dashboard.runtime.{{ $.Values.garden.domainOverride }}.{{ required ".Values.global.region missing" .region }}.cloud.sap
-  - discovery.runtime.{{ $.Values.garden.domainOverride }}.{{ required ".Values.global.region missing" .region }}.cloud.sap
+  - dashboard.runtime.{{ $.Values.garden.domainOverride }}.{{ required ".Values.global.region missing" .Values.global.region }}.cloud.sap
+  - discovery.runtime.{{ $.Values.garden.domainOverride }}.{{ required ".Values.global.region missing" .Values.global.region }}.cloud.sap
 {{- else }}
 {{- with .Values.global }}
   - dashboard.runtime-garden.{{ required ".Values.global.cluster missing" .cluster }}.{{ required ".Values.global.region missing" .region }}.cloud.sap


### PR DESCRIPTION
Fixed a scope bug: in the garden.domainOverride branch, .region was read from the root context instead of .Values.global.region, causing .Values.global.region missing. Aligned it with the already-correct else branch and records.yaml.
prt-* clusters are the only ones to use domainOverride + dashboard, hence require this change. 
Change is transparent for gardener on rt-* clusters.