### PR TITLE
prometheus-server: disable local compaction (workaround for operator v0.93.0 bug)

### DIFF
--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 8.2.6
+version: 8.2.7
 appVersion: v3.11.2
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/prometheus-server.yaml
+++ b/common/prometheus-server/templates/prometheus-server.yaml
@@ -191,6 +191,14 @@ spec:
 {{ toYaml $.Values.thanos.spec | indent 4 }}
   {{- end -}}
 
+  # Workaround for prometheus-operator v0.93.0 bug where the delay-compact-file
+  # path coordination between Prometheus and Thanos sidecar uses mismatched
+  # relative/absolute paths, causing the sidecar to crash.
+  # See: https://github.com/prometheus-operator/prometheus-operator/issues/XXXX
+  {{- if $.Values.disableCompaction }}
+  disableCompaction: true
+  {{- end }}
+
   {{ if $.Values.resources }}
   # Kubernetes resource requests and limits if configured.
   resources:

--- a/common/prometheus-server/templates/prometheus-server.yaml
+++ b/common/prometheus-server/templates/prometheus-server.yaml
@@ -191,10 +191,7 @@ spec:
 {{ toYaml $.Values.thanos.spec | indent 4 }}
   {{- end -}}
 
-  # Workaround for prometheus-operator v0.93.0 bug where the delay-compact-file
-  # path coordination between Prometheus and Thanos sidecar uses mismatched
-  # relative/absolute paths, causing the sidecar to crash.
-  # See: https://github.com/prometheus-operator/prometheus-operator/issues/XXXX
+  # See: https://github.com/prometheus-operator/prometheus-operator/issues/8763 for more details
   {{- if $.Values.disableCompaction }}
   disableCompaction: true
   {{- end }}

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -30,7 +30,7 @@ image:
 # Mandatory name for a single Prometheus. To setup multiple, define a list of .Values.names or .Values.global.targets.
 # Disable local compaction on Prometheus.
 # Workaround for prometheus-operator v0.93.0 bug with Thanos sidecar path mismatch.
-# Remove once https://github.com/prometheus-operator/prometheus-operator/issues/XXXX is fixed.
+# See: https://github.com/prometheus-operator/prometheus-operator/issues/8763 for more details
 disableCompaction: true
 
 # The name is used to find relevant aggregation and alerting rules.

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -28,6 +28,11 @@ image:
   repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/prom/prometheus
 
 # Mandatory name for a single Prometheus. To setup multiple, define a list of .Values.names or .Values.global.targets.
+# Disable local compaction on Prometheus.
+# Workaround for prometheus-operator v0.93.0 bug with Thanos sidecar path mismatch.
+# Remove once https://github.com/prometheus-operator/prometheus-operator/issues/XXXX is fixed.
+disableCompaction: true
+
 # The name is used to find relevant aggregation and alerting rules.
 # Examples: kubernetes, openstack, infrastructure, maia, vmware etc.
 name: 


### PR DESCRIPTION
## What

Disables local compaction on Prometheus by setting `disableCompaction: true` in the Prometheus CR.

## Why

After upgrading to prometheus-operator v0.93.0, the new delay-compact-file integration https://github.com/prometheus-operator/prometheus-operator/pull/8694 causes the Thanos sidecar to crash in a loop.

This causes the sidecar to exit after 10 minutes with exit code 1, restarting the pod repeatedly and triggering `CC3TestPrometheusRegionDown` alerts.

## Fix

Setting `disableCompaction: true` skips the broken `compactionModeDelayed` code path and falls back to the legacy behavior. Thanos Compactor handles compaction globally and not the prometheus container itself. 


Created an ticket in upstream prometheus-operator repository -  https://github.com/prometheus-operator/prometheus-operator/issues/8763