### PR TITLE
Bump prometheus-server 8.2.5 → 8.2.7 in all consumer charts

### DIFF
--- a/system/infra-monitoring/Chart.lock
+++ b/system/infra-monitoring/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.5
+  version: 8.2.7
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1

--- a/system/infra-monitoring/Chart.yaml
+++ b/system/infra-monitoring/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: infra-monitoring
-version: 2.6.13
+version: 2.6.14
 description: Prometheus Infrastructure Monitoring and Metrics Collection
 icon: https://raw.githubusercontent.com/prometheus/prometheus/main/web/ui/static/img/prometheus_logo.svg
 dependencies:
   - name: prometheus-server
     alias: prometheus_infra_collector
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.5
+    version: 8.2.7
     condition: prometheus_infra_collector.enabled
 
   - name: thanos

--- a/system/prometheus-infra/Chart.lock
+++ b/system/prometheus-infra/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.5
+  version: 8.2.7
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1

--- a/system/prometheus-infra/Chart.yaml
+++ b/system/prometheus-infra/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: prometheus-infra
 description: Prometheus Infrastructure Monitoring - A Helm chart for the operated regional Prometheus Frontend for monitoring infrastructure.
-version: 3.7.11
+version: 3.7.12
 dependencies:
   - name: prometheus-server
     alias: prometheus-infra-frontend
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.5
+    version: 8.2.7
     condition: prometheus-infra-frontend.enabled
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/prometheus-kubernetes/Chart.lock
+++ b/system/prometheus-kubernetes/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.5
+  version: 8.2.7
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1

--- a/system/prometheus-kubernetes/Chart.yaml
+++ b/system/prometheus-kubernetes/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 description: Common Kubernetes Prometheus
 name: prometheus-kubernetes
-version: 1.1.11
+version: 1.1.12
 home: https://github.com/sapcc/helm-charts/tree/master/system/prometheus-kubernetes
 dependencies:
   - name: prometheus-server
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.5
+    version: 8.2.7
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.3.1

--- a/system/storage-monitoring/Chart.lock
+++ b/system/storage-monitoring/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.5
+  version: 8.2.7
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1

--- a/system/storage-monitoring/Chart.yaml
+++ b/system/storage-monitoring/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: storage-monitoring
 description: Prometheus and Thanos setup for netapp-exporter 
-version: 0.7.12
+version: 0.7.13
 dependencies:
   - name: prometheus-server
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.5
+    version: 8.2.7
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.3.1

--- a/system/vmware-monitoring/Chart.lock
+++ b/system/vmware-monitoring/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.5
+  version: 8.2.7
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1

--- a/system/vmware-monitoring/Chart.yaml
+++ b/system/vmware-monitoring/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: vmware-monitoring
-version: 2.4.13
+version: 2.4.14
 description: VMware Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.5
+    version: 8.2.7
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.3.1


### PR DESCRIPTION
Follow-up to #12607: bumps the prometheus-server dependency from 8.2.5 → 8.2.7 across all consumer charts so they pick up the `disableCompaction: true` workaround for the prometheus-operator v0.93.0 Thanos sidecar path mismatch bug.

Updated charts (Chart.yaml + Chart.lock):
- prometheus-kubernetes: 1.1.11 → 1.1.12
- infra-monitoring: 2.6.13 → 2.6.14
- prometheus-infra: 3.7.11 → 3.7.12
- storage-monitoring: 0.7.12 → 0.7.13
- vmware-monitoring: 2.4.13 → 2.4.14

See: https://github.com/prometheus-operator/prometheus-operator/issues/8763