### PR TITLE
Regenerate Chart.lock digests for prometheus-server 8.2.7

### DIFF
--- a/system/infra-monitoring/Chart.lock
+++ b/system/infra-monitoring/Chart.lock
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:327c101b823657416a4a5f6611688eacb6b804f05f3afa7a9f0eaa2a4cfd1ddb
-generated: "2026-06-08T11:51:22.73093+02:00"
+digest: sha256:ef7d18a9965d37010f5fc331b0c0150dcd8477e1ecbf1676f1ecbfd801021ada
+generated: "2026-08-19T13:59:23.646485+02:00"

--- a/system/prometheus-infra/Chart.lock
+++ b/system/prometheus-infra/Chart.lock
@@ -14,5 +14,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:8d7116ea5b0470bd30012b1da6c710ce6e7db96aaf5f3efb0470201cdc56e5cf
-generated: "2026-06-08T11:51:40.390908+02:00"
+digest: sha256:bdabc995a7b66fb39737e7b1915b5778882d6bb742ad15cc2b839dd539be96d6
+generated: "2026-08-19T13:59:29.521878+02:00"

--- a/system/prometheus-kubernetes/Chart.lock
+++ b/system/prometheus-kubernetes/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:fa2dd1454b6aea33dee266ea1c3116e54a18d0ccf096bcb55d873219453077d6
-generated: "2026-06-08T11:52:06.261897+02:00"
+digest: sha256:893dcb3605765966cc1d04f5152c1c8347a6961a5ad5023dccd6602b0ed25295
+generated: "2026-08-19T13:59:17.6403+02:00"

--- a/system/storage-monitoring/Chart.lock
+++ b/system/storage-monitoring/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:e43358761fe207f696bee4a93ce9cb6c20b8106c4c1187c430502a74fd119e29
-generated: "2026-06-08T11:52:34.80399+02:00"
+digest: sha256:2d852c5111a02f172019b342a92e4d6211ce4856b7776de164d0d74c8fa3a92a
+generated: "2026-08-19T13:59:35.798361+02:00"

--- a/system/vmware-monitoring/Chart.lock
+++ b/system/vmware-monitoring/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:fa2dd1454b6aea33dee266ea1c3116e54a18d0ccf096bcb55d873219453077d6
-generated: "2026-06-08T11:52:53.208588+02:00"
+digest: sha256:893dcb3605765966cc1d04f5152c1c8347a6961a5ad5023dccd6602b0ed25295
+generated: "2026-08-19T13:59:42.045398+02:00"


### PR DESCRIPTION
The Chart.lock files had stale digests from the previous prometheus-server version (8.2.5). This caused `helm dependency build` to fail with:

```
Error: the lock file (Chart.lock) is out of sync with the dependencies file (Chart.yaml). Please update the dependencies
```

Ran `helm dependency update` on all affected charts to regenerate the digests now that prometheus-server:8.2.7 is published to the OCI registry.

Updated charts:
- prometheus-kubernetes
- infra-monitoring
- prometheus-infra
- storage-monitoring
- vmware-monitoring