### PR TITLE
Bump prometheus-server 8.2.7 → 8.2.8 in all consumer charts

### DIFF
--- a/openstack/prometheus-openstack/Chart.lock
+++ b/openstack/prometheus-openstack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.6
+  version: 8.2.8
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1
@@ -14,5 +14,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:bff6a5c65bfb24d46ef8eafc6922eed664d56cf1b1c1ccd70cd490e646ced685
-generated: "2026-07-22T17:20:52.562767+05:30"
+digest: sha256:5f4d1c781415398115ae1719ce54febad80fdc756483c3cf59b3c2f89f4a30e2
+generated: "2026-08-19T14:26:06.927832+02:00"

--- a/openstack/prometheus-openstack/Chart.yaml
+++ b/openstack/prometheus-openstack/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: openstack-prometheus
-version: 3.7.12
+version: 3.7.13
 description: Prometheus Openstack Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server
     alias: openstack-prometheus
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.6
+    version: 8.2.8
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.3.1

--- a/system/infra-monitoring/Chart.lock
+++ b/system/infra-monitoring/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.7
+  version: 8.2.8
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:ef7d18a9965d37010f5fc331b0c0150dcd8477e1ecbf1676f1ecbfd801021ada
-generated: "2026-08-19T13:59:23.646485+02:00"
+digest: sha256:3b5d95367c137d7442a73d62609dc1fb6f3c4b70594941d6e2d3258bfc332bf4
+generated: "2026-08-19T14:16:56.31594+02:00"

--- a/system/infra-monitoring/Chart.yaml
+++ b/system/infra-monitoring/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: infra-monitoring
-version: 2.6.14
+version: 2.6.15
 description: Prometheus Infrastructure Monitoring and Metrics Collection
 icon: https://raw.githubusercontent.com/prometheus/prometheus/main/web/ui/static/img/prometheus_logo.svg
 dependencies:
   - name: prometheus-server
     alias: prometheus_infra_collector
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.7
+    version: 8.2.8
     condition: prometheus_infra_collector.enabled
 
   - name: thanos

--- a/system/prometheus-infra/Chart.lock
+++ b/system/prometheus-infra/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.7
+  version: 8.2.8
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1
@@ -14,5 +14,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:bdabc995a7b66fb39737e7b1915b5778882d6bb742ad15cc2b839dd539be96d6
-generated: "2026-08-19T13:59:29.521878+02:00"
+digest: sha256:7672037b8f41155ba2ecc1bcdc5aea7aa4ba050bd3554b0b74147a4a7151d512
+generated: "2026-08-19T14:17:02.094023+02:00"

--- a/system/prometheus-infra/Chart.yaml
+++ b/system/prometheus-infra/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: prometheus-infra
 description: Prometheus Infrastructure Monitoring - A Helm chart for the operated regional Prometheus Frontend for monitoring infrastructure.
-version: 3.7.12
+version: 3.7.13
 dependencies:
   - name: prometheus-server
     alias: prometheus-infra-frontend
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.7
+    version: 8.2.8
     condition: prometheus-infra-frontend.enabled
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/prometheus-kubernetes/Chart.lock
+++ b/system/prometheus-kubernetes/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.7
+  version: 8.2.8
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:893dcb3605765966cc1d04f5152c1c8347a6961a5ad5023dccd6602b0ed25295
-generated: "2026-08-19T13:59:17.6403+02:00"
+digest: sha256:16818f8c6f1c3edfb4d8402614e7e8e0ebd45b2371a2c1b4e1a8457ab253ddf9
+generated: "2026-08-19T14:16:50.582736+02:00"

--- a/system/prometheus-kubernetes/Chart.yaml
+++ b/system/prometheus-kubernetes/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 description: Common Kubernetes Prometheus
 name: prometheus-kubernetes
-version: 1.1.12
+version: 1.1.13
 home: https://github.com/sapcc/helm-charts/tree/master/system/prometheus-kubernetes
 dependencies:
   - name: prometheus-server
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.7
+    version: 8.2.8
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.3.1

--- a/system/storage-monitoring/Chart.lock
+++ b/system/storage-monitoring/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.7
+  version: 8.2.8
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:2d852c5111a02f172019b342a92e4d6211ce4856b7776de164d0d74c8fa3a92a
-generated: "2026-08-19T13:59:35.798361+02:00"
+digest: sha256:0ad8d6e19b476c4ed97bdafec53ab907fd5ebfe21009e0e30cd802bbd4d21fa3
+generated: "2026-08-19T14:17:07.890319+02:00"

--- a/system/storage-monitoring/Chart.yaml
+++ b/system/storage-monitoring/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: storage-monitoring
 description: Prometheus and Thanos setup for netapp-exporter 
-version: 0.7.13
+version: 0.7.14
 dependencies:
   - name: prometheus-server
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.7
+    version: 8.2.8
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.3.1

--- a/system/vmware-monitoring/Chart.lock
+++ b/system/vmware-monitoring/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.2.7
+  version: 8.2.8
 - name: thanos
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.1
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:893dcb3605765966cc1d04f5152c1c8347a6961a5ad5023dccd6602b0ed25295
-generated: "2026-08-19T13:59:42.045398+02:00"
+digest: sha256:16818f8c6f1c3edfb4d8402614e7e8e0ebd45b2371a2c1b4e1a8457ab253ddf9
+generated: "2026-08-19T14:17:14.103635+02:00"

--- a/system/vmware-monitoring/Chart.yaml
+++ b/system/vmware-monitoring/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: vmware-monitoring
-version: 2.4.14
+version: 2.4.15
 description: VMware Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.2.7
+    version: 8.2.8
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.3.1


### PR DESCRIPTION
Updates prometheus-server dependency to 8.2.8 which includes the template lint fix.

Updated charts:
- prometheus-kubernetes: 1.1.12 → 1.1.13
- infra-monitoring: 2.6.14 → 2.6.15
- prometheus-infra: 3.7.12 → 3.7.13
- storage-monitoring: 0.7.13 → 0.7.14
- vmware-monitoring: 2.4.14 → 2.4.15