### PR TITLE
[archer] enable pprof profiling endpoints

### DIFF
--- a/openstack/archer/templates/etc/_archer.ini.tpl
+++ b/openstack/archer/templates/etc/_archer.ini.tpl
@@ -2,6 +2,8 @@
 debug = {{ .Values.debug }}
 prometheus = true
 prometheus_listen = 0.0.0.0:{{ required ".Values.metrics.port missing" .Values.metrics.port }}
+pprof = {{ .Values.pprof.enabled }}
+pprof_listen = 127.0.0.1:{{ .Values.pprof.port }}
 sentry = true
 endpoint_type = internal
 

--- a/openstack/archer/values.yaml
+++ b/openstack/archer/values.yaml
@@ -125,6 +125,11 @@ ingress:
 metrics:
   port: 9090
 
+# net/http/pprof profiling endpoints, bound to localhost (reach via `kubectl port-forward`).
+pprof:
+  enabled: true
+  port: 6060
+
 audit:
   enabled: true
   user: rabbitmq


### PR DESCRIPTION
Enables the net/http/pprof profiling endpoints (added in the archer service via sapcc/archer#822) for the API server and both agents.

The endpoints bind to localhost inside each pod and are reachable with `kubectl port-forward <pod> 6060:6060`, then pointing `go tool pprof`/`go tool trace` at http://127.0.0.1:6060/debug/pprof/.

Exposed through a new `pprof.enabled` value (default `true`), with the listen port controlled by `pprof.port`.