### PR TITLE
fix(hermes): silence absent-metric alerts for log-router in regions where it is not deployed

### DIFF
--- a/openstack/hermes/alerts/kubernetes/pod.alerts.tpl
+++ b/openstack/hermes/alerts/kubernetes/pod.alerts.tpl
@@ -67,6 +67,7 @@ groups:
           dashboard: hermes-overview
           persesDashboard: "https://perses.{{ .Values.global.region }}.{{ .Values.global.tld }}/projects/observability/dashboards/hermes-overview"
           meta: "{{`{{ $labels.pod }}`}}/{{`{{ $labels.container }}`}} is {{`{{ $labels.reason }}`}}"
+          no_alert_on_absence: "true" # metric only exists when a pod is in a waiting state
         annotations:
           summary: Pod is not running
           description: "The container {{`{{ $labels.pod }}`}}/{{`{{ $labels.container }}`}} is in {{`{{ $labels.reason }}`}} state for more than 15 minutes."

--- a/openstack/hermes/alerts/openstack/api.alerts.tpl
+++ b/openstack/hermes/alerts/openstack/api.alerts.tpl
@@ -236,6 +236,7 @@ groups:
       description: Hermes monitoring endpoint is down => Hermes is down
       summary: Hermes API is not available, check pod logs
 
+{{- if .Values.logRouter.enabled }}
   - alert: OpenstackHermesLogRouterRabbitMQDisconnected
     expr: sum(log_router_rabbitmq_connected) == 0
     for: 2m
@@ -286,3 +287,4 @@ groups:
     annotations:
       description: "Log Router is failing to write to the admin-tier storage. The admin tier provides unconditional compliance copies of all audit events. Sustained errors mean audit records are missing from the admin bucket."
       summary: "Log Router admin-tier write errors — compliance data at risk"
+{{- end }}


### PR DESCRIPTION
## Summary
- Gate the three `OpenstackHermesLogRouter*` alerts behind `{{- if .Values.logRouter.enabled }}` so they are not rendered in regions without log-router
- Add `no_alert_on_absence: "true"` to `OpenstackHermesPodNotRunning` — the metric only exists when a pod is in a waiting state (matches pattern of sibling alerts)

## Context
Log-router is only deployed in eu-de-1, eu-de-3, and qa-de-1. The alert rules were rendered unconditionally, so the absent-metrics-operator flagged missing metrics in all other regions. This produced ~30+ INFO alerts every scrape cycle across NA, AP, LA, and EU regions.