### PR TITLE
fix(owner-info): add missing owner-info blocks to calico, calico-crds, prometheus-crds

### DIFF
--- a/system/calico-crds/Chart.yaml
+++ b/system/calico-crds/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: calico-crds
 description: A Helm chart for the Calico.
 type: application
-version: 3.32.1
+version: 3.32.2

--- a/system/calico-crds/values.yaml
+++ b/system/calico-crds/values.yaml
@@ -1,3 +1,8 @@
+owner-info:
+  support-group: containers
+  service: calico
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/calico-crds
+
 # The CRDs required can be found in the crds folder and are only applied on helm install.
 # As a convenience when using helm upgrade they are also installed via templates if installCRDs is true.
 # WARNING: Delete with care as removing of the CRDs will remove all instances of it.

--- a/system/calico/Chart.yaml
+++ b/system/calico/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: calico
 description: A Helm chart for the Calico.
 type: application
-version: 1.2.5
+version: 1.2.6
 appVersion: v3.32.1

--- a/system/calico/values.yaml
+++ b/system/calico/values.yaml
@@ -1,3 +1,8 @@
+owner-info:
+  support-group: containers
+  service: calico
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/calico
+
 global:
   clusterCIDR: ""
 config:

--- a/system/prometheus-crds/Chart.yaml
+++ b/system/prometheus-crds/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: prometheus-crds
 description: A Helm chart containing Prometheus CRDs.
 type: application
-version: 10.0.0
+version: 10.0.1

--- a/system/prometheus-crds/values.yaml
+++ b/system/prometheus-crds/values.yaml
@@ -1,3 +1,8 @@
+owner-info:
+  support-group: observability
+  service: prometheus
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/prometheus-crds
+
 # The CRDs required can be found in the crds folder and are only applied on helm install.
 # As a convenience when using helm upgrade they are also installed via templates if installCRDs is true.
 # WARNING: Delete with care as removing of the CRDs will remove all instances of it.


### PR DESCRIPTION
## Summary

Adds missing `owner-info` blocks to 3 charts that had none:

- `system/calico` → `support-group: containers`
- `system/calico-crds` → `support-group: containers`
- `system/prometheus-crds` → `support-group: observability`

Without an `owner-info` block, the owner-label-injector webhook cannot inject `ccloud.sap.com/support-group` labels, causing these services to appear without a support group in Heureka or to fall back to incorrect assignments.

## Test plan

- [ ] Verify `owner-info` blocks present in all 3 charts
- [ ] After merge and rollout, confirm calico/calico-crds appear under `containers` and prometheus-crds under `observability` in Heureka

Replaces #12572