### PR TITLE
Bump kvm-ha-service helm chart

### DIFF
--- a/openstack/kvm-ha-service/Chart.lock
+++ b/openstack/kvm-ha-service/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kvm-ha-service
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.7
+  version: 1.0.9
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:f347f27191766b3ae7000670441e92d81575b0f8a7b47dc21d08cba0a626c327
-generated: "2026-06-04T10:11:40.340999+02:00"
+digest: sha256:821366d8bae3fc2ad5083ce47d91ac58ddc2805cfede18e1974a6a564e17275a
+generated: "2026-08-20T10:55:36.155354+02:00"

--- a/openstack/kvm-ha-service/Chart.yaml
+++ b/openstack/kvm-ha-service/Chart.yaml
@@ -3,11 +3,11 @@ name: kvm-ha-service
 description: Helm Chart for KVM HA Service with internal dependencies
 type: application
 
-version: 0.1.6
+version: 0.1.7
 
 dependencies:
 - name: kvm-ha-service
-  version: '1.0.7'
+  version: '1.0.9'
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
To make use of the new deployment annotations, bumping the helm chart