### PR TITLE
fix(archer): normalize migration job name in DEPENDENCY_JOBS

### DIFF
--- a/openstack/archer/templates/deployment-f5.yaml
+++ b/openstack/archer/templates/deployment-f5.yaml
@@ -38,7 +38,7 @@ spec:
             - name: NAMESPACE
               value: {{ $.Release.Namespace | quote }}
             - name: DEPENDENCY_JOBS
-              value: {{ include "archer.fullname" $ }}-migration-{{ $.Values.image.tag | required ".Values.image.tag is required" }}
+              value: {{ include "archer.fullname" $ }}-migration-{{ $.Values.image.tag | required ".Values.image.tag is required" | replace "." "-" }}
             - name: COMMAND
               value: "true"
       containers:

--- a/openstack/archer/templates/deployment.yaml
+++ b/openstack/archer/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace | quote }}
             - name: DEPENDENCY_JOBS
-              value: {{ include "archer.fullname" . }}-migration-{{ .Values.image.tag | required ".Values.image.tag is required" }}
+              value: {{ include "archer.fullname" . }}-migration-{{ .Values.image.tag | required ".Values.image.tag is required" | replace "." "-" }}
             - name: COMMAND
               value: "true"
       containers:


### PR DESCRIPTION
The migration Job name uses `| replace "." "-"` to produce a valid Kubernetes resource name from the image tag, but the `DEPENDENCY_JOBS` references in `deployment.yaml` and `deployment-f5.yaml` were missing that transform. This caused the kubernetes-entrypoint wait-for init container to look for a job that doesn't exist.