### PR TITLE
[mariadb] update backup and sidecar images

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.42.1 - 2026/08/20
+* `maria-back-me-up` updated to `10.11-20260820143216` with ceph-s3 fixes
+* updated optional `go-maria-sync` deployment image tag
+* updated sidecar images:
+  * `mysqld-exporter` updated to `v0.20.0`
+  * `mariadb-credentials-updater`
+  * `pod-readiness`
+* chart version bumped
+
 ## v0.42.0 - 2026/07/13
 * support SSE-C for Ceph S3 backup uploads
   * default at `global.mariadb.backup_v2.ceph_s3.sse_customer_key`

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.42.0
+version: 0.42.1
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.18
 dependencies:

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -210,13 +210,13 @@ use_alternate_registry: false
 
 readiness:
   image: pod-readiness
-  image_version: "20260521132613"
+  image_version: "20260820145244"
   # set to true if backup_v2 is not enabled, but readiness sidecar is required
   useSidecar: false
 
 credentialUpdater:
   image: 'shared-app-images/alpine-mariadb'
-  imageTag: 'python3.13-alpine3.23-20260506191108'
+  imageTag: 'python3.13-alpine3.24-20260820144936'
   checkInterval: '10'
 
 backup_v2:
@@ -224,7 +224,7 @@ backup_v2:
   cohost_with_mariadb: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "10.11-20260706142324"
+  image_version: "10.11-20260820143216"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60
@@ -281,7 +281,7 @@ backup_v2:
 metrics:
   enabled: true
   image: prom/mysqld-exporter
-  image_version: v0.19.0
+  image_version: v0.20.0
   port: "9104"
   flags:
     - collect.binlog_size
@@ -305,10 +305,10 @@ sync:
   init:
     enabled: false
     image: 'shared-app-images/alpine-mariadb'
-    imageTag: 'python3.13-alpine3.23-20260207085008'
+    imageTag: 'python3.13-alpine3.24-20260820144936'
   image:
     name: "go-maria-sync"
-    tag: "20260205163034"
+    tag: "20260813190947"
   backup:
     service: null
     swift:


### PR DESCRIPTION
* `maria-back-me-up` updated to `10.11-20260820143216` with ceph-s3 fixes
* updated optional `go-maria-sync` deployment image tag
* updated sidecar images:
  * `mysqld-exporter` updated to `v0.20.0`
  * `mariadb-credentials-updater`
  * `pod-readiness`
* chart version bumped