### PR TITLE
[memcached] update memcached to 1.6.45

### DIFF
--- a/common/memcached/CHANGELOG.md
+++ b/common/memcached/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.19 - 2026/08/21
+
+* memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1645) bumped to `1.6.45-alpine3.24`
+* memcached-exporter [version](https://github.com/prometheus/memcached_exporter/releases/tag/v0.17.0) bumped to `v0.17.0`
+* chart version bumped
+
 ## v0.6.18 - 2026/07/09
 
 * memcached bumped to `1.6.44-alpine3.24` [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1644), includes `1.6.43`  [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1643) fixes

--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: memcached
-version: 0.6.18
-appVersion: 1.6.44
+version: 0.6.19
+appVersion: 1.6.45
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/memcached/tags/
 ##
 image: library/memcached
-imageTag: 1.6.44-alpine3.24
+imageTag: 1.6.45-alpine3.24
 # set to true to use .Values.global.dockerHubMirrorAlternateRegion instead of .Values.global.dockerHubMirror
 use_alternate_registry: false
 
@@ -54,7 +54,7 @@ vpa:
 metrics:
   enabled: true
   image: "prom/memcached-exporter"
-  imageTag: "v0.16.0"
+  imageTag: "v0.17.0"
 
   port: "9150"
   resources:


### PR DESCRIPTION
* memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1645) bumped to `1.6.45-alpine3.24`
* memcached-exporter [version](https://github.com/prometheus/memcached_exporter/releases/tag/v0.17.0) bumped to `v0.17.0`
* chart version bumped