### PR TITLE
Revert common/thanos: re-add ingress.kubernetes.io/ annotation prefix

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 1.3.6
+version: 1.3.7
 appVersion: v0.41.0
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/ingress-grpc.yaml
+++ b/common/thanos/templates/ingress-grpc.yaml
@@ -11,16 +11,22 @@ metadata:
     disco: "true"
     kubernetes.io/tls-acme: "true"
     {{- if $.Values.grpcIngress.authentication.sso.enabled}}
+    ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.grpcIngress.authentication.sso.authTLSSecret missing" $.Values.grpcIngress.authentication.sso.authTLSSecret | quote }}
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.grpcIngress.authentication.sso.authTLSSecret missing" $.Values.grpcIngress.authentication.sso.authTLSSecret | quote }}
+    ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyDepth | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyDepth | quote }}
+    ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyClient missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyClient | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyClient missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
+    ingress.kubernetes.io/backend-protocol: {{ required "$.Values.grpcIngress.authentication.grpc.backendProtocol missing" $.Values.grpcIngress.authentication.grpc.backendProtocol | quote }}
     nginx.ingress.kubernetes.io/backend-protocol: {{ required "$.Values.grpcIngress.authentication.grpc.backendProtocol missing" $.Values.grpcIngress.authentication.grpc.backendProtocol | quote }}
+    ingress.kubernetes.io/ssl-redirect: {{ required "$.Values.grpcIngress.authentication.grpc.sslRedirect missing" $.Values.grpcIngress.authentication.grpc.sslRedirect | quote }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ required "$.Values.grpcIngress.authentication.grpc.sslRedirect missing" $.Values.grpcIngress.authentication.grpc.sslRedirect | quote }}
     {{- if $.Values.grpcIngress.annotations }}
 {{ toYaml $.Values.grpcIngress.annotations | indent 4 }}
     {{ end }}
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 spec:

--- a/common/thanos/templates/ingress-internal.yaml
+++ b/common/thanos/templates/ingress-internal.yaml
@@ -11,14 +11,18 @@ metadata:
     disco: "true"
     kubernetes.io/tls-acme: "true"
     {{- if $.Values.internalIngress.authentication.sso.enabled}}
+    ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.internalIngress.authentication.sso.authTLSSecret missing" $.Values.internalIngress.authentication.sso.authTLSSecret | quote }}
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.internalIngress.authentication.sso.authTLSSecret missing" $.Values.internalIngress.authentication.sso.authTLSSecret | quote }}
+    ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
+    ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyClient missing" $.Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyClient missing" $.Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if $.Values.internalIngress.annotations }}
 {{ toYaml $.Values.internalIngress.annotations | indent 4 }}
     {{ end }}
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 spec:

--- a/common/thanos/templates/ingress.yaml
+++ b/common/thanos/templates/ingress.yaml
@@ -11,20 +11,26 @@ metadata:
     disco: "true"
     kubernetes.io/tls-acme: "true"
     {{- if $.Values.ingress.authentication.oauth.enabled }}
+    ingress.kubernetes.io/auth-url: {{ required "$.Values.ingress.authentication.oauth.authURL missing" $.Values.ingress.authentication.oauth.authURL }}
     nginx.ingress.kubernetes.io/auth-url: {{ required "$.Values.ingress.authentication.oauth.authURL missing" $.Values.ingress.authentication.oauth.authURL }}
     {{- if $.Values.ingress.authentication.oauth.authSignInURL }}
+    ingress.kubernetes.io/auth-signin: {{ $.Values.ingress.authentication.oauth.authSignInURL }}
     nginx.ingress.kubernetes.io/auth-signin: {{ $.Values.ingress.authentication.oauth.authSignInURL }}
     {{- end }}
     {{ end }}
     {{- if $.Values.ingress.authentication.sso.enabled}}
+    ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.ingress.authentication.sso.authTLSSecret missing" $.Values.ingress.authentication.sso.authTLSSecret | quote }}
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.ingress.authentication.sso.authTLSSecret missing" $.Values.ingress.authentication.sso.authTLSSecret | quote }}
+    ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyDepth missing" $.Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyDepth missing" $.Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
+    ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyClient missing" $.Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyClient missing" $.Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if $.Values.ingress.annotations }}
 {{ toYaml $.Values.ingress.annotations | indent 4 }}
     {{ end }}
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 spec:

--- a/common/thanos/templates/ingressroute-grpc.yaml
+++ b/common/thanos/templates/ingressroute-grpc.yaml
@@ -9,6 +9,7 @@ metadata:
   name: {{ include "thanos.fullName" (list $name $root) }}-grpc
   {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
   annotations:
+    ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
   {{- end }}
 spec:


### PR DESCRIPTION
This reverts the `common/thanos` changes from PR #11953 which removed the `ingress.kubernetes.io/` annotation prefix from thanos ingress templates.

Re-adding the duplicate annotations to maintain backward compatibility.

Reverts thanos-related changes from: https://github.com/sapcc/helm-charts/pull/11953