### PR TITLE
Herems update logstash exporter

### DIFF
--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm audit management for Openstack
 maintainers:
   - name: notque
 name: hermes
-version: 0.2.5
+version: 0.2.6
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/hermes/alerts/openstack/api.alerts.tpl
+++ b/openstack/hermes/alerts/openstack/api.alerts.tpl
@@ -170,7 +170,7 @@ groups:
       summary: "RabbitMQ blocking publishers (free-disk watermark)"
 
   - alert: OpenstackHermesLogstashPlugins
-    expr: sum(increase(logstash_node_plugin_events_out_total[30m])) <= 0
+    expr: sum(increase(logstash_stats_pipeline_plugin_events_out[30m])) <= 0
     labels:
       context: logstash
       severity: warning
@@ -186,7 +186,7 @@ groups:
       summary: "Hermes logstash plugin {{`{{ $labels.plugin }}`}} has stopped transmitting data"
 
   - alert: OpenstackHermesLogstashKafkaFailure
-    expr: sum(rate(logstash_node_plugin_failures_total{namespace=~"hermes",plugin="kafka"}[10m])) > 0
+    expr: sum(rate(logstash_stats_pipeline_plugin_bulk_requests_errors{namespace=~"hermes",plugin="kafka"}[10m])) + sum(rate(logstash_stats_pipeline_plugin_documents_non_retryable_failures{namespace=~"hermes",plugin="kafka"}[10m])) > 0
     for: 5m
     labels:
       context: logstash
@@ -203,7 +203,7 @@ groups:
       summary: "Hermes logstash Kafka output plugin is failing"
 
   - alert: OpenstackHermesLogstashPluginsJDBCStaticFailure
-    expr: sum(rate(logstash_node_plugin_failures_total{namespace=~"hermes",plugin="jdbc_static"}[10m])) > 0
+    expr: sum(rate(logstash_stats_pipeline_plugin_bulk_requests_errors{namespace=~"hermes",plugin="jdbc_static"}[10m])) + sum(rate(logstash_stats_pipeline_plugin_documents_non_retryable_failures{namespace=~"hermes",plugin="jdbc_static"}[10m])) > 0
     labels:
       context: logstash
       severity: warning

--- a/openstack/hermes/templates/logstash-deployment.yaml
+++ b/openstack/hermes/templates/logstash-deployment.yaml
@@ -162,19 +162,16 @@ spec:
               cpu: {{required ".Values.resources_requests_cpu_ls is missing" .Values.resources_requests_cpu_ls}}
 
         - name: logstash-exporter
-          image: {{ .Values.global.dockerHubMirror | required ".Values.global.dockerHubMirror is missing" }}/kuskoman/logstash-exporter:v1.9.1
+          image: {{ .Values.global.dockerHubMirror | required ".Values.global.dockerHubMirror is missing" }}/bonniernews/logstash_exporter:v0.1.2
           imagePullPolicy: IfNotPresent
-          env:
-            - name: LOGSTASH_URL
-              value: "http://localhost:9600"
-            - name: PORT
-              value: "9198"
-          startupProbe:
-            httpGet:
-              path: /healthcheck
-              port: 9198
-            failureThreshold: 24
-            periodSeconds: 10
+          command: ["/bin/sh", "-c"]
+          ## Delay start of logstash-exporter to give logstash more time to come online.
+          args:
+            - >-
+              sleep 120;
+              exec /logstash_exporter
+                --logstash.endpoint=http://localhost:9600
+                --web.listen-address=:9198
           ports:
             - name: ls-exporter
               containerPort: 9198

--- a/openstack/hermes/templates/logstash-deployment.yaml
+++ b/openstack/hermes/templates/logstash-deployment.yaml
@@ -162,16 +162,19 @@ spec:
               cpu: {{required ".Values.resources_requests_cpu_ls is missing" .Values.resources_requests_cpu_ls}}
 
         - name: logstash-exporter
-          image: {{ .Values.global.dockerHubMirror | required ".Values.global.dockerHubMirror is missing" }}/bonniernews/logstash_exporter:v0.1.2
+          image: {{ .Values.global.dockerHubMirror | required ".Values.global.dockerHubMirror is missing" }}/kuskoman/logstash-exporter:v1.9.1
           imagePullPolicy: IfNotPresent
-          command: ["/bin/sh", "-c"]
-          ## Delay start of logstash-exporter to give logstash more time to come online.
-          args:
-            - >-
-              sleep 120;
-              exec /logstash_exporter
-                --logstash.endpoint=http://localhost:9600
-                --web.listen-address=:9198
+          env:
+            - name: LOGSTASH_URL
+              value: "http://localhost:9600"
+            - name: PORT
+              value: "9198"
+          startupProbe:
+            httpGet:
+              path: /healthcheck
+              port: 9198
+            failureThreshold: 24
+            periodSeconds: 10
           ports:
             - name: ls-exporter
               containerPort: 9198

--- a/openstack/hermes/templates/logstash-service.yaml
+++ b/openstack/hermes/templates/logstash-service.yaml
@@ -11,6 +11,7 @@ metadata:
     prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus }}
     prometheus.io/scrape: "true"
     prometheus.io/port: "9198"
+    prometheus.io/path: "/metrics"
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     linkerd.io/inject: enabled
     {{- end }}


### PR DESCRIPTION
## Motivation
  The `bonniernews/logstash_exporter` (v0.1.2) is unmaintained and exposes metrics under a
  `logstash_node_*` naming scheme that no longer matches what the Prometheus alerts and Perses
  dashboard query. Replacing it with `kuskoman/logstash-exporter` (v1.9.1) brings an actively
  maintained exporter with richer pipeline and JVM metrics, but requires updating all dependent
  metric names throughout the chart.

  ## What Changed
  - **logstash-exporter image**: replaced `bonniernews/logstash_exporter:v0.1.2` with
    `kuskoman/logstash-exporter:v1.9.1`; configuration switched from CLI flags to env vars
    (`LOGSTASH_URL`, `PORT`) and the `sleep 120` startup hack replaced with a proper `startupProbe`
  - **logstash Service**: added `prometheus.io/path: "/metrics"` annotation — the new exporter
    serves metrics at `/metrics` (returning a 301 from `/`), which Prometheus does not follow
  - **Alerts**: updated all three logstash alert expressions (`OpenstackHermesLogstashPlugins`,
    `OpenstackHermesLogstashKafkaFailure`, `OpenstackHermesLogstashPluginsJDBCStaticFailure`) to use
    the new `logstash_stats_*` metric names

  ## Usage
 With kuskoman/logstash-exporter, the metrics names are changed heavily, therefore we also need to update the alert and dashbaord. This PR must be merged with the dashboard PR
