### PR TITLE
fix(kube-monitoring): bump blackbox-exporter, configmap-reload, x509-cert-exporter and kube-state-metrics to fix critical CVEs

### DIFF
--- a/prometheus-exporters/blackbox-exporter/Chart.yaml
+++ b/prometheus-exporters/blackbox-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: Prometheus blackbox exporter chart.
 name: blackbox-exporter
-version: 2.3.3
-appVersion: v0.26.0
+version: 2.3.4
+appVersion: v0.28.0

--- a/prometheus-exporters/blackbox-exporter/values.yaml
+++ b/prometheus-exporters/blackbox-exporter/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: prom/blackbox-exporter
-  tag: v0.26.0
+  tag: v0.28.0
   pullPolicy: IfNotPresent
 
 service:
@@ -24,4 +24,4 @@ ingress:
 configmapReload:
   image:
     repository: jimmidyson/configmap-reload
-    tag: v0.4.0
+    tag: v0.15.0

--- a/prometheus-exporters/blackbox-exporter/values.yaml
+++ b/prometheus-exporters/blackbox-exporter/values.yaml
@@ -1,4 +1,4 @@
-#global:
+# global:
 #  region:
 #  domain:
 #  Optional mirror for images.

--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.10
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 8.0.0
+  version: 8.4.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.1
@@ -43,6 +43,6 @@ dependencies:
   version: 0.1.5
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 4.1.0
-digest: sha256:2bc034469eb6b0fb34d593b9fca6e113a3279b63623c0ce7987460814ae8a8f9
-generated: "2026-08-18T16:42:49.533801+02:00"
+  version: 4.2.0
+digest: sha256:7b02be1aae5a46248c87140a63edfa44d13bb1ee8835d11db9dd77c34a33499a
+generated: "2026-08-24T09:42:47.331033+02:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.8.5
+version: 4.8.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -11,7 +11,7 @@ dependencies:
     version: "^1"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 8.0.0
+    version: 8.4.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.1
@@ -52,4 +52,4 @@ dependencies:
     version: 0.1.5
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 4.1.0
+    version: 4.2.0

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.10
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 8.0.0
+  version: 8.4.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.1
@@ -52,6 +52,6 @@ dependencies:
   version: 0.1.5
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 4.1.0
-digest: sha256:6bf7713878de8fc4912a6005670e538aba10561ab51b43bcfa3027e21fc825a1
-generated: "2026-08-18T16:42:18.312873+02:00"
+  version: 4.2.0
+digest: sha256:d5c9972f1cdd78cbaf2f1e38c61cd60a2c04c104b01cd57f480d5afb1ceda5a7
+generated: "2026-08-24T09:40:20.558691+02:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.10.6
+version: 7.10.7
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -11,7 +11,7 @@ dependencies:
     version: "^1"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 8.0.0
+    version: 8.4.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.1
@@ -63,4 +63,4 @@ dependencies:
     version: 0.1.5
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 4.1.0
+    version: 4.2.0

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 2.3.3
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 8.0.0
+  version: 8.4.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.1
@@ -46,6 +46,6 @@ dependencies:
   version: 0.1.5
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 4.1.0
-digest: sha256:39f96c36c10ee15067e7dd48595abccf892d7306a98f41d6f97fd11f37606a14
-generated: "2026-08-18T16:42:37.412803+02:00"
+  version: 4.2.0
+digest: sha256:7ad930c92308548c7883542ad93a1c85eb457435b41d2662c5ed013e8a83e72d
+generated: "2026-08-24T09:30:15.935025+02:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.11.6
+version: 4.11.7
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -14,7 +14,7 @@ dependencies:
     version: "^2.3"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 8.0.0
+    version: 8.4.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.1
@@ -54,4 +54,4 @@ dependencies:
     version: 0.1.5
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 4.1.0
+    version: 4.2.0

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.10
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 8.0.0
+  version: 8.4.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -43,6 +43,6 @@ dependencies:
   version: 1.0.0
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 4.1.0
-digest: sha256:f9cc09e12037979818845f258a07fe436abfa0ad828366a96664e26364fe3c20
-generated: "2026-08-18T16:41:39.100832+02:00"
+  version: 4.2.0
+digest: sha256:608a02a7149ff4fb039b160be690f13dc512a3b5951b7ad7ea0d941430f6ed05
+generated: "2026-08-24T09:32:35.01837+02:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.13.5
+version: 4.13.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -10,7 +10,7 @@ dependencies:
     version: "^1"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 8.0.0
+    version: 8.4.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.x"
@@ -50,4 +50,4 @@ dependencies:
     version: "^1.x"
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 4.1.0
+    version: 4.2.0

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.10
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 8.0.0
+  version: 8.4.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.1
@@ -46,6 +46,6 @@ dependencies:
   version: 0.1.5
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 4.1.0
-digest: sha256:64a0d86e433c1d274d42ca872ac415826effbc54ae272087fa04c8a19ebe5caa
-generated: "2026-08-18T16:42:02.895701+02:00"
+  version: 4.2.0
+digest: sha256:32a67f48bddd4fdcf580c6bed69513f5970a7fa77fedcedf75e601a3ed034326
+generated: "2026-08-24T09:35:57.571199+02:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.11.5
+version: 6.11.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -11,7 +11,7 @@ dependencies:
     version: "^1"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 8.0.0
+    version: 8.4.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.1
@@ -54,4 +54,4 @@ dependencies:
     version: 0.1.5
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 4.1.0
+    version: 4.2.0


### PR DESCRIPTION
## Summary

- **blackbox-exporter**: \`v0.26.0\` → \`v0.28.0\` in \`prometheus-exporters/blackbox-exporter\` (fixes CVE-2026-39821 Critical/10.0 and multiple High CVEs)
- **configmap-reload**: \`v0.4.0\` → \`v0.15.0\` (fixes CVE-2025-61729 High/7.5 and multiple High CVEs)
- **x509-certificate-exporter**: chart \`4.1.0\` → \`4.2.0\` (fixes 11 High CVEs incl. CVE-2026-39821, CVE-2026-42502/42506)
- **kube-state-metrics**: chart \`8.0.0\` → \`8.4.0\` (KSM image **2.19.1 → 2.20.0**, fixes CVE-2026-39821)

## Affected pipelines

All five kube-monitoring variants:
\`kube-monitoring-metal\`, \`kube-monitoring-scaleout\`, \`kube-monitoring-virtual\`, \`kube-monitoring-kubernikus\`, \`kube-monitoring-admin-k3s\`

## Notes

- **configmap-reload v0.15.0** is only available on ghcr.io (not Docker Hub). The template already guards with \`global.ghcrIoMirror\`; all clusters deploying kube-monitoring have this set in their region globals.
- **KSM 2.20.0**: kube_pod_status_reason cardinality change has no impact — zero PrometheusRules in this repo reference that metric.

## Test plan

- [ ] CI (\`ct lint\` + version increment check) passes
- [ ] \`chart-test/upload-charts\` publishes new \`blackbox-exporter\` chart after merge
- [ ] kube-monitoring-metal deployed to qa-de-1, blackbox-exporter running on \`v0.28.0\`
- [ ] x509-certificate-exporter running on new version
- [ ] kube-state-metrics scraping metrics correctly (v2.20.0)