### PR TITLE
fix(kube-system): pin reloader image tag to v1.4.21 in values.yaml

### DIFF
--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.16
+version: 6.14.17
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -281,6 +281,7 @@ secrets-injector:
 reloader:
   image:
     repository: 'keppel.global.cloud.sap/ccloud-ghcr-io-mirror/stakater/reloader'
+    tag: v1.4.21
 
 owner-label-injector:
   enabled: true

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.11
+version: 5.13.12
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-scaleout/values.yaml
+++ b/system/kube-system-scaleout/values.yaml
@@ -77,4 +77,4 @@ reloader:
   enabled: false
   image:
     name: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/stakater/reloader
-    tag: v1.0.72
+    tag: v1.4.21


### PR DESCRIPTION
## Summary

Follow-up to PR #12633 (reloader chart 2.2.14 → 2.2.16).

The chart bump did not update the running reloader image because the previous Helm release had stored `tag: v1.4.19` in its state, and Helm reused it during upgrade. The fix explicitly pins `tag: v1.4.21` (appVersion of chart 2.2.16) in `values.yaml` so the image is updated on next deployment.

- **kube-system-metal**: add `tag: v1.4.21` (reloader is enabled here)
- **kube-system-scaleout**: update stale `tag: v1.0.72` → `v1.4.21` (reloader is disabled, cleanup only)

## Test plan

- [ ] kube-system-metal deployed to qa-de-1, reloader running on `v1.4.21`