### PR TITLE
[cc-gardener] Add missing floatingPool name patterns to central cloudprofile

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.24
+version: 0.38.25
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/managedresources/cloudprofile-openstack.yaml
+++ b/global/cc-gardener/managedresources/cloudprofile-openstack.yaml
@@ -54,6 +54,134 @@ spec:
         region: na-us-2
       - name: FloatingIP*
         region: na-us-3
+      # from cloudprofile converged-cloud-cis
+      - name: cis-ciea-*
+        region: ap-ae-1
+      - name: cis-ciea-*
+        region: ap-au-1
+      - name: cis-ciea-*
+        region: ap-cn-1
+      - name: cis-ciea-*
+        region: ap-jp-1
+      - name: cis-ciea-*
+        region: ap-jp-2
+      - name: cis-ciea-*
+        region: ap-sa-1
+      - name: cis-ciea-*
+        region: ap-sa-2
+      - name: cis-ciea-*
+        region: eu-de-1
+      - name: cis-ciea-*
+        region: eu-de-2
+      - name: cis-ciea-*
+        region: eu-nl-1
+      - name: cis-ciea-*
+        region: la-br-1
+      - name: cis-ciea-*
+        region: na-ca-1
+      - name: cis-ciea-*
+        region: na-us-1
+      - name: cis-ciea-*
+        region: na-us-2
+      - name: cis-ciea-*
+        region: na-us-3
+      - name: cis-gmp-*
+        region: ap-ae-1
+      - name: cis-gmp-*
+        region: ap-au-1
+      - name: cis-gmp-*
+        region: ap-cn-1
+      - name: cis-gmp-*
+        region: ap-jp-1
+      - name: cis-gmp-*
+        region: ap-jp-2
+      - name: cis-gmp-*
+        region: ap-sa-1
+      - name: cis-gmp-*
+        region: ap-sa-2
+      - name: cis-gmp-*
+        region: eu-de-1
+      - name: cis-gmp-*
+        region: eu-de-2
+      - name: cis-gmp-*
+        region: eu-nl-1
+      - name: cis-gmp-*
+        region: la-br-1
+      - name: cis-gmp-*
+        region: na-ca-1
+      - name: cis-gmp-*
+        region: na-us-1
+      - name: cis-gmp-*
+        region: na-us-2
+      - name: cis-gmp-*
+        region: na-us-3
+      - name: cis-sni-*
+        region: eu-de-1
+      - name: cis-sni-*
+        region: eu-de-2
+      # from cloudprofile converged-cloud-neo
+      - name: neo-*
+        region: eu-de-1
+      - name: neo-gmp-*
+        region: ap-ae-1
+      - name: neo-gmp-*
+        region: ap-au-1
+      - name: neo-gmp-*
+        region: ap-cn-1
+      - name: neo-gmp-*
+        region: ap-jp-1
+      - name: neo-gmp-*
+        region: ap-jp-2
+      - name: neo-gmp-*
+        region: ap-sa-1
+      - name: neo-gmp-*
+        region: ap-sa-2
+      - name: neo-gmp-*
+        region: eu-de-1
+      - name: neo-gmp-*
+        region: eu-de-2
+      - name: neo-gmp-*
+        region: eu-nl-1
+      - name: neo-gmp-*
+        region: la-br-1
+      - name: neo-gmp-*
+        region: na-ca-1
+      - name: neo-gmp-*
+        region: na-us-1
+      - name: neo-gmp-*
+        region: na-us-2
+      - name: neo-gmp-*
+        region: na-us-3
+      - name: gmp-*
+        region: ap-ae-1
+      - name: gmp-*
+        region: ap-au-1
+      - name: gmp-*
+        region: ap-cn-1
+      - name: gmp-*
+        region: ap-jp-1
+      - name: gmp-*
+        region: ap-jp-2
+      - name: gmp-*
+        region: ap-sa-1
+      - name: gmp-*
+        region: ap-sa-2
+      - name: gmp-*
+        region: eu-de-1
+      - name: gmp-*
+        region: eu-de-2
+      - name: gmp-*
+        region: eu-nl-1
+      - name: gmp-*
+        region: la-br-1
+      - name: gmp-*
+        region: na-ca-1
+      - name: gmp-*
+        region: na-us-1
+      - name: gmp-*
+        region: na-us-2
+      - name: gmp-*
+        region: na-us-3
       loadBalancerProviders:
       - name: f5
     machineImages: {{ toYaml .Values.extensions.openstack.providerConfig.machineImages | nindent 6 }}


### PR DESCRIPTION
Follow-up to #12250

Adds floating pool name patterns from `converged-cloud-cis` and `converged-cloud-neo` profiles to the central openstack cloudprofile so all use cases enabled by those profiles are also allowed here.

New patterns added:
- `cis-ciea-*` (all regions, from converged-cloud-cis)
- `cis-gmp-*` (all regions, from converged-cloud-cis)
- `cis-sni-*` (eu-de-1, eu-de-2 only, from converged-cloud-cis)
- `neo-*` (eu-de-1 only, from converged-cloud-neo)
- `neo-gmp-*` (all regions, from converged-cloud-neo)
- `gmp-*` (all regions, from converged-cloud-neo)

Region assignments match the source profiles exactly.