### PR TITLE
fix(kube-system): update Chart.lock to kube-dns 0.4.1 and bump chart versions

### DIFF
--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.7
 - name: kube-dns
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.0
+  version: 0.4.1
 - name: kube-proxy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.41
@@ -74,5 +74,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:21c0a45ea716454ae9ad57771e04bfed1ca66d288f8a6d40440b47b3cd049832
-generated: "2026-08-24T09:19:09.864483+02:00"
+digest: sha256:8ebcdbf5588902b82f61610af792b500ccdf1a11fba93d76d6fd4fb386329abf
+generated: "2026-08-25T08:12:49.412477+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.16
+version: 6.14.17
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.0.2
 - name: kube-dns
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.0
+  version: 0.4.1
 - name: kube-proxy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.41
@@ -56,5 +56,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.16
-digest: sha256:a37e6f92aee4d8580de52f09dc9927195a99ebd8edab7508af03d17b45dbc7d7
-generated: "2026-08-24T09:20:56.920331+02:00"
+digest: sha256:c0cac5368eb4612c3a04e08ffed487c50b87090bedac07ebc754b6b73cabbcd4
+generated: "2026-08-25T08:13:07.319285+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.14
+version: 4.9.15
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac


### PR DESCRIPTION
## Problem

After merging #12633, CoreDNS was not updated on metal/virtual clusters for two reasons:

1. **Chart.lock still pinned kube-dns 0.4.0** — kube-dns 0.4.1 (CoreDNS 1.14.7) was not yet published in the Keppel registry at the time of the PR, so `helm dep update` resolved to 0.4.0. The chart now uses `0.4.1`.
2. **Chart version was not bumped in #12633** — the pipeline saw no version change and did not trigger a deployment.

## Changes

- `system/kube-system-metal/Chart.lock`: kube-dns 0.4.0 → 0.4.1
- `system/kube-system-metal/Chart.yaml`: version 6.14.16 → 6.14.17
- `system/kube-system-virtual/Chart.lock`: kube-dns 0.4.0 → 0.4.1
- `system/kube-system-virtual/Chart.yaml`: version 4.9.14 → 4.9.15

## Related

- Follows #12633 — bump coredns to 1.14.7
- cc/unified-kubernetes#1410