### PR TITLE
[barbican] fix constant hash in migration job_name

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.9.0
+version: 0.9.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/ci/test-values.yaml
+++ b/openstack/barbican/ci/test-values.yaml
@@ -3,6 +3,7 @@ global:
   registry: my.docker.registry
   dbPassword: topSecret
   barbican_service_password: topSecret
+  clusterDNSSearchDomain: cluster.local
   registryAlternateRegion: other.docker.registry
   dockerHubMirror: myRegistry/dockerhub
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate

--- a/openstack/barbican/templates/_helpers.tpl
+++ b/openstack/barbican/templates/_helpers.tpl
@@ -35,7 +35,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
           (include "utils.proxysql.volumes" .)
           (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")
       | join "\n" }}
-    {{- $hash := empty .Values.proxysql.mode | ternary "" $all | sha256sum }}
+    {{- $hash := $all | sha256sum }}
 {{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersionBarbicanApi | required "Please set barbican.imageVersionBarbicanApi" }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
- hash $all unconditionally; ternary "" hashed a constant when proxysql.mode was unset
- add missing global.clusterDNSSearchDomain to ci/test-values
- bump chart 0.9.0 -> 0.9.1