### PR TITLE
[mariadb] Update MariaDB version to 10.11.19

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.42.2 - 2026/08/25
+* MariaDB version updated to [10.11.19](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.19)
+* `maria-back-me-up` updated to `10.11-20260825091346`
+* chart version bumped
+
 ## v0.42.1 - 2026/08/20
 * `maria-back-me-up` updated to `10.11-20260820143216` with ceph-s3 fixes
 * updated optional `go-maria-sync` deployment image tag

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,9 +2,9 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.42.1
+version: 0.42.2
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
-appVersion: 10.11.18
+appVersion: 10.11.19
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -9,7 +9,7 @@ global:
       enabled: true
 
 name: null
-image: library/mariadb:10.11.18
+image: library/mariadb:10.11.19
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
@@ -224,7 +224,7 @@ backup_v2:
   cohost_with_mariadb: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "10.11-20260820143216"
+  image_version: "10.11-20260825091346"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
* MariaDB version updated to [10.11.19](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.19)
* `maria-back-me-up` updated to `10.11-20260825091346`
* chart version bumped