### PR TITLE
[keystone] restrict admin domain grants

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.13.2
+version: 0.13.3
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -63,6 +63,15 @@
 
 "blocklist_projects": "'{{required ".Values.api.cloudAdminProjectId is missing" .Values.api.cloudAdminProjectId}}':%(target.project.id)s"
 
+{{- if .Values.api.adminDomainIds }}
+# ccloud: blocklisted roles and grants on blocklisted projects may only be
+# assigned to recipients (users or groups) whose domain is an admin domain
+# (e.g. Default, ccadmin). Enabled per-region via api.adminDomainIds.
+"admin_domain_recipient": "{{ range $i, $d := .Values.api.adminDomainIds }}{{ if $i }} or {{ end }}'{{ $d }}':%(target.user.domain_id)s or '{{ $d }}':%(target.group.domain_id)s{{ end }}"
+"blocklisted_role_grant_ok": "not rule:blocklist_roles or rule:admin_domain_recipient"
+"restricted_project_grant_ok": "not rule:blocklist_projects or rule:admin_domain_recipient"
+{{- end }}
+
 # Show access rule details.
 # GET  /v3/users/{user_id}/access_rules/{access_rule_id}
 # HEAD  /v3/users/{user_id}/access_rules/{access_rule_id}
@@ -515,7 +524,7 @@
 # PUT  /v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects
 # Intended scope(s): system, domain
 #"identity:create_grant": "(role:admin and system_scope:all) or ((role:admin and domain_id:%(target.user.domain_id)s and domain_id:%(target.project.domain_id)s) or (role:admin and domain_id:%(target.user.domain_id)s and domain_id:%(target.domain.id)s) or (role:admin and domain_id:%(target.group.domain_id)s and domain_id:%(target.project.domain_id)s) or (role:admin and domain_id:%(target.group.domain_id)s and domain_id:%(target.domain.id)s)) and (domain_id:%(target.role.domain_id)s or None:%(target.role.domain_id)s)"
-"identity:create_grant": "rule:cloud_admin or rule:domain_admin_for_grants or rule:project_admin_for_grants"
+"identity:create_grant": "{{- if .Values.api.adminDomainIds }}({{- end }}rule:cloud_admin or rule:domain_admin_for_grants or rule:project_admin_for_grants{{- if .Values.api.adminDomainIds }}) and rule:blocklisted_role_grant_ok and rule:restricted_project_grant_ok{{- end }}"
 
 # Revoke a role grant between a target and an actor. A target can be
 # either a domain or a project. An actor can be either a user or a

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -116,6 +116,15 @@ api:
   cloudAdminProjectName: admin
   cloudAdminProjectId: ""
 
+  # Domain IDs considered "admin domains". When non-empty, blocklisted roles
+  # (blocklist_roles) and grants on blocklisted projects (blocklist_projects)
+  # may only be assigned to recipients (users or groups) whose domain is in
+  # this list, even for cloud-admins. Empty = restriction disabled.
+  # The Default domain id is the literal "default"; ccadmin is a per-region UUID.
+  # Enable per-region in secrets, e.g.:
+  #   adminDomainIds: ["default", "<ccadmin domain uuid>"]
+  adminDomainIds: []
+
   ## specify override default tags to be added to each newly created project
   ## else they will be calculated based on the availability zones
   # default_tags:


### PR DESCRIPTION
Add api.adminDomainIds: when non-empty, grants of blocklisted roles and grants on blocklisted projects (e.g. the cloud-admin project) may only be assigned to recipients (users or groups) whose domain is in the list, even for cloud-admins. Recipients are matched by target.user/group.domain_id (Keystone exposes no domain name for grant recipients). Disabled by default (empty list) and enabled per-region via secrets.