### PR TITLE
fix(cc-ceph-csi): bump rook operator to v1.17.5

### DIFF
--- a/system/cc-ceph-csi/Chart.yaml
+++ b/system/cc-ceph-csi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cc-ceph-csi
 description: A minimal Helm chart for the Rook operator to run Ceph and CSI components
 type: application
-version: 0.4.14
-appVersion: 1.17.1
+version: 0.4.15
+appVersion: 1.17.5
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/cc-ceph-csi/values.yaml
+++ b/system/cc-ceph-csi/values.yaml
@@ -12,7 +12,7 @@ registries:
 
 operator:
   replicas: 1
-  image: rook/ceph:v1.17.1
+  image: rook/ceph:v1.17.5
   logLevel: INFO # The logging level for the operator: ERROR | WARNING | INFO | DEBUG
   metricAddress: :8080
 


### PR DESCRIPTION
## Problem

Rook operator v1.17.1 fails cluster reconciliation when Prometheus Operator CRDs are not installed:

```
failed to reconcile CephCluster: failed to enable mgr services: failed to enable service monitor:
service monitor could not be enabled: the server could not find the requested resource (post servicemonitors.monitoring.coreos.com)
```

This blocks OSD creation on new runtime clusters where Gardener hasn't yet deployed Prometheus CRDs.

## Fix

Bump to v1.17.5 which includes the backport of [rook/rook@ca12916](https://github.com/rook/rook/commit/ca1291643852c6b95d1526e6bf5769238c7ec1ee) — `mgr: continue reconcile if prometheus not installed`. The ServiceMonitor creation failure is logged but no longer blocks reconciliation.

This also aligns with `cc-ceph` which already runs rook-ceph 1.17.5.

## Changes

- `operator.image`: `rook/ceph:v1.17.1` → `rook/ceph:v1.17.5`
- Chart version: `0.4.14` → `0.4.15`
- appVersion: `1.17.1` → `1.17.5`