### PR TITLE
metal-operator-remote: add remote kubeconfig for metaldata

### DIFF
--- a/system/metal-operator-remote/Chart.yaml
+++ b/system/metal-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.46
+version: 0.6.47
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-operator-remote/templates/metaldata.yaml
+++ b/system/metal-operator-remote/templates/metaldata.yaml
@@ -63,6 +63,16 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        env:
+          - name: KUBECONFIG
+            value: /var/run/remote-kubeconfig/kubeconfig
+        volumeMounts:
+          - name: remote-serviceaccount
+            mountPath: /var/run/secrets/kubernetes.io/remote-serviceaccount
+            readOnly: true
+          - name: remote-kubeconfig
+            mountPath: /var/run/remote-kubeconfig
+            readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -74,3 +84,15 @@ spec:
           type: RuntimeDefault
       serviceAccountName: {{ include "chart.resourceName" (dict "suffix" "metaldata" "context" $) }}
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: remote-serviceaccount
+          secret:
+            secretName: metal-operator-remote-kubeconfig
+            items:
+              - key: token
+                path: token
+              - key: bundle.crt
+                path: ca.crt
+        - name: remote-kubeconfig
+          configMap:
+            name: remote-kubeconfig


### PR DESCRIPTION
metaldata needs to run against the same remote kubeconfig metal-operator-remote uses.