### PR TITLE
[gatekeeper] allow archer caps in archer namespace for all clusters

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -1032,7 +1032,6 @@ spec:
         - SYS_ADMIN
         - SYS_CHROOT
 
-      {{- if eq .Values.cluster_name "eu-de-3" }}
       - matchNamespace: archer
         matchRepository: ccloud/archer
         justification: |
@@ -1065,7 +1064,6 @@ spec:
         - SETPCAP
         - SYS_ADMIN
         - SYS_PTRACE
-      {{- end }}
 
       {{- if eq .Values.cluster_type "baremetal" "admin" }}
       # TODO: delete after full migration to RSBC images


### PR DESCRIPTION
The `ccloud/archer` and `ccloud/loci-neutron` allowlist entries for the `archer` namespace were gated behind `{{- if eq .Values.cluster_name "eu-de-3" }}`, so any cluster other than eu-de-3 deploying archer in the `archer` namespace (rather than `monsoon3`) had no matching policy exception.

la-br-1 hit this with admission failing on `KILL` — needed by archer-ni-agent to signal HAProxy processes that have dropped to uid `nobody` across the uid boundary.

Both entries are now unconditional.