### PR TITLE
[kvm-cinder-netapp-operator] Remove netapp secret template

### DIFF
--- a/openstack/kvm-cinder-netapp-operator/Chart.yaml
+++ b/openstack/kvm-cinder-netapp-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the kvm-cinder-netapp-operator
 name: kvm-cinder-netapp-operator
-version: 0.6.0
+version: 0.6.1
 appVersion: "0.6.0"
 dependencies:
 - name: utils

--- a/openstack/kvm-cinder-netapp-operator/templates/netapp_secret.yaml
+++ b/openstack/kvm-cinder-netapp-operator/templates/netapp_secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.netapp.secret.name }}
-  namespace: {{ required ".Values.managed_resources_namespace is missing" $.Values.managed_resources_namespace }}
-type: kubernetes.io/basic-auth
-stringData:
-  username: {{ required ".Values.netapp.secret.username is missing" .Values.netapp.secret.username }}
-  password: {{ required ".Values.netapp.secret.password is missing" .Values.netapp.secret.password }}

--- a/openstack/kvm-cinder-netapp-operator/values.yaml
+++ b/openstack/kvm-cinder-netapp-operator/values.yaml
@@ -20,7 +20,3 @@ volumeconfig:
 netapp:
   watchers: []
   filers: []
-  secret:
-    name: 'kvm-cinder-netapp-operator-secret'
-    username:
-    password:


### PR DESCRIPTION
Secret no longer required with adoption of netapp-credential-rotator.