### PR TITLE
[kube-cni] select multus install path by major version

### DIFF
--- a/system/kube-cni/Chart.yaml
+++ b/system/kube-cni/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Kubernetes CNI Plugins
 name: kube-cni
-version: 0.0.4
+version: 0.0.5

--- a/system/kube-cni/templates/daemonset.yaml
+++ b/system/kube-cni/templates/daemonset.yaml
@@ -34,13 +34,14 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
 {{- if .Values.plugins.multus }}
+      {{- $multusMajor := .Values.images.multus.tag | toString | trimPrefix "v" | splitList "." | first | int }}
       - name: install-multus-cni-plugin
         image: "{{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.images.multus.image }}:{{ .Values.images.multus.tag }}"
         command:
         - cp
         args:
         - -f
-        - /multus-cni/multus-cni
+        - {{ if ge $multusMajor 4 }}/multus-cni/multus{{ else }}/multus-cni/multus-cni{{ end }}
         - /opt/cni/bin/multus-cni
         volumeMounts:
         - name: cni-plugin


### PR DESCRIPTION
- copy /multus-cni/multus on tag >= 4 (4.x renamed the thin binary), /multus-cni/multus-cni otherwise
- bump chart to 0.0.5