### PR TITLE
[mariadb][neutron] bump db chart dependency

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.41.0
+  version: 0.42.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:2b5d73cb1f213b76ff6e55deab2da3398a31ffabefca0f1c954a1616004a2f40
-generated: "2026-07-22T10:07:55.006327656+02:00"
+digest: sha256:03e2886b457007ad7734cc3a60abaae88ba13faf9972c21e0aa2c8562942f038
+generated: "2026-08-26T14:09:42.573507+03:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,13 +2,13 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.8
+version: 0.3.9
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.41.0
+    version: 0.42.2
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* support SSE-C for Ceph S3 backup uploads
* support base64-encoded SSE-C key in config for maria-back-me-up
* fix Ceph S3 multipart download on restore in maria-back-me-up
* update sidecar images (mysqld-exporter v0.20.0, mariadb-credentials-updater, pod-readiness)
* update MariaDB to 10.11.19