### PR TITLE
[mariadb][nova] bump db chart dependency

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,19 +1,19 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.2
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.7.0
@@ -28,7 +28,7 @@ dependencies:
   version: 0.38.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
@@ -37,7 +37,7 @@ dependencies:
   version: 0.25.4
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
@@ -59,5 +59,5 @@ dependencies:
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.25.4
-digest: sha256:60cbcd670763b02e4ed630c199779448d30986de1565a6db8cb026b7217bba18
-generated: "2026-07-02T13:24:51.531621695+02:00"
+digest: sha256:d96bcc845c5acfd7602d532ba1b0b712829db03e06bfbe9d4491b24f4e906f04
+generated: "2026-08-26T14:10:07.537825+03:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -3,13 +3,13 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.6.7
+version: 0.6.8
 appVersion: "bobcat"
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.39.0
+    version: 0.42.2
   - alias: pxc_db
     condition: pxc_db.enabled
     name: pxc-db
@@ -19,7 +19,7 @@ dependencies:
     condition: mariadb_api.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.39.0
+    version: 0.42.2
   - alias: pxc_db_api
     condition: pxc_db_api.enabled
     name: pxc-db
@@ -29,7 +29,7 @@ dependencies:
     condition: mariadb_cell1.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.39.0
+    version: 0.42.2
   - name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.7.0
@@ -47,7 +47,7 @@ dependencies:
     condition: mariadb_cell2.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.39.0
+    version: 0.42.2
   - alias: pxc_db_cell2
     condition: pxc_db_cell2.enabled
     name: pxc-db
@@ -62,7 +62,7 @@ dependencies:
     condition: mariadb_cell3.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.39.0
+    version: 0.42.2
   - alias: pxc_db_cell3
     condition: pxc_db_cell3.enabled
     name: pxc-db


### PR DESCRIPTION
* optionally cohost the mariadb and mariadb-backup pods on the same node
* support configurable S3 object lock on backup uploads
* support SSE-C for Ceph S3 backup uploads
* support base64-encoded SSE-C key in config for maria-back-me-up
* fix Ceph S3 multipart download on restore in maria-back-me-up
* update sidecar images (mysqld-exporter v0.20.0, mariadb-credentials-updater, pod-readiness)
* update MariaDB to 10.11.19