### PR TITLE
[mariadb][designate] bump db chart dependency

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.6.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.17
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.4.62
-digest: sha256:149d2688d2204950f8b8d0ac417ca1f9bf0743c417ab42e5c5f070833dfdefbe
-generated: "2026-07-21T10:12:36.388849+02:00"
+digest: sha256:37731eb7c8929d0619b65f897cc6302358c2434809f2445c96e785db3bf14b5e
+generated: "2026-08-26T14:06:54.059612+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.39.0
+    version: 0.42.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.17


### PR DESCRIPTION
* optionally cohost the mariadb and mariadb-backup pods on the same node
* support configurable S3 object lock on backup uploads
* support SSE-C for Ceph S3 backup uploads
* support base64-encoded SSE-C key in config for maria-back-me-up
* fix Ceph S3 multipart download on restore in maria-back-me-up
* update sidecar images (mysqld-exporter v0.20.0, mariadb-credentials-updater, pod-readiness)
* update MariaDB to 10.11.19