### PR TITLE
[mariadb][kmip] bump db chart dependency

### DIFF
--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -7,15 +7,15 @@ dependencies:
   version: 1.1.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.38.0
+  version: 0.38.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.8.1
-digest: sha256:08510c539ca4c202e8da5154d6b631e1cf7de3c81cc6fea0d26f5a761364a1a4
-generated: "2026-06-26T15:26:15.664358+03:00"
+digest: sha256:cdad139dcdee9aeecc65986e003ed20baf25ca5ab0090014b0ac6164457fa63e
+generated: "2026-08-26T14:06:44.418546+03:00"

--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Chart Version
-version: 0.3.10
+version: 0.3.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -38,7 +38,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.39.0
+    version: 0.42.2
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* optionally cohost the mariadb and mariadb-backup pods on the same node
* support configurable S3 object lock on backup uploads
* support SSE-C for Ceph S3 backup uploads
* support base64-encoded SSE-C key in config for maria-back-me-up
* fix Ceph S3 multipart download on restore in maria-back-me-up
* update sidecar images (mysqld-exporter v0.20.0, mariadb-credentials-updater, pod-readiness)
* update MariaDB to 10.11.19