### PR TITLE
[mariadb][cinder] bump db chart dependency

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.37.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:59294a6cad1396f3b0e6ce993144e6658dac12df2b7a53385052e34cea5acb53
-generated: "2026-06-26T15:23:49.80565+03:00"
+digest: sha256:f378c1f88055ec126bf33e8501dfe1d72d28ae6fea4c6686dcfade67ca58505b
+generated: "2026-08-26T14:04:33.605517+03:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -3,14 +3,14 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.4.1
+version: 0.4.2
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.37.1
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.39.0
+    version: 0.42.2
     condition: mariadb.enabled
   - name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* optionally cohost the mariadb and mariadb-backup pods on the same node
* support configurable S3 object lock on backup uploads
* support SSE-C for Ceph S3 backup uploads
* support base64-encoded SSE-C key in config for maria-back-me-up
* fix Ceph S3 multipart download on restore in maria-back-me-up
* update sidecar images (mysqld-exporter v0.20.0, mariadb-credentials-updater, pod-readiness)
* update MariaDB to 10.11.19