### PR TITLE
[mariadb][manila] bump db chart dependency

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,13 +4,13 @@ dependencies:
   version: 1.1.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.17
+  version: 0.6.19
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.8.1
@@ -19,12 +19,12 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.2
+  version: 0.25.8
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.4.67
+  version: 2.5.6
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.38.0
-digest: sha256:d08600b06f146a895590dc5d3ee14a00c1e7eb2cc9f41ed70ec80f9fa9ef4c84
-generated: "2026-06-26T15:26:37.052129+03:00"
+  version: 0.38.1
+digest: sha256:7851ab798ef5fbe11bdf738d08759c3a19137663704ecacd810dadadb9df6eee
+generated: "2026-08-26T14:10:27.278282+03:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.7.1
+version: 0.7.2
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
* optionally cohost the mariadb and mariadb-backup pods on the same node
* support configurable S3 object lock on backup uploads
* support SSE-C for Ceph S3 backup uploads
* support base64-encoded SSE-C key in config for maria-back-me-up
* fix Ceph S3 multipart download on restore in maria-back-me-up
* update sidecar images (mysqld-exporter v0.20.0, mariadb-credentials-updater, pod-readiness)
* update MariaDB to 10.11.19
* bump memcached, redis and rabbitmq chart dependencies