### PR TITLE
[mariadb][ironic] bump db chart dependency

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.42.0
+  version: 0.42.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.18
+  version: 0.6.19
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.8.1
@@ -16,12 +16,12 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.7
+  version: 0.25.8
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.38.1
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:74df0b12ec755173aada579081435eeb39b5342f024b9da367d7a3d6ea7cfc5c
-generated: "2026-07-28T12:54:42.802296413+02:00"
+digest: sha256:82f51dd534e8fccb8d4e6affaa3d7822845e4655062a3288fd0a42a7bad5928b
+generated: "2026-08-26T14:10:41.02818+03:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.17
+version: 0.2.18
 dependencies:
   - condition: mariadb.enabled
     name: mariadb


### PR DESCRIPTION
* support base64-encoded SSE-C key in config for maria-back-me-up
* fix Ceph S3 multipart download on restore in maria-back-me-up
* update sidecar images (mysqld-exporter v0.20.0, mariadb-credentials-updater, pod-readiness)
* update MariaDB to 10.11.19