### PR TITLE
openstack-hypervisor-operator: pin subchart to v1.2.2

### DIFF
--- a/openstack/openstack-hypervisor-operator/Chart.lock
+++ b/openstack/openstack-hypervisor-operator/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.0
+  version: 0.38.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: openstack-hypervisor-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cobaltcore-dev/charts
-  version: 1.2.3
-digest: sha256:01c1ce5b926d22b12712f219f883bf046ea1abb4d9590a0fdad2bbc28afafa87
-generated: "2026-05-29T12:23:53.746177185Z"
+  version: 1.2.2
+digest: sha256:f2900df70dd4a2903130baa00af9299fb9454bfaa4c592f4f6a9a9dc91cf87c4
+generated: "2026-08-26T11:16:08.241028-04:00"

--- a/openstack/openstack-hypervisor-operator/Chart.yaml
+++ b/openstack/openstack-hypervisor-operator/Chart.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: '>= 0.0.0'
 - name: openstack-hypervisor-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cobaltcore-dev/charts
-  version: '>= 0.0.0'
+  version: '1.2.2'


### PR DESCRIPTION
v1.2.3 needs to be rolled out alongside ha-operator. Pin the subchart to 1.2.2 until that dependency is ready.

The subchart's deployment template uses `.Chart.AppVersion` as the image tag (not `.Values...image.tag`), so the only effective way to control the deployed version is via the Chart.lock pin.