### PR TITLE
[neutron] add configuration for unbound in dhcpagents

### DIFF
--- a/openstack/neutron/templates/configmap-etc.yaml
+++ b/openstack/neutron/templates/configmap-etc.yaml
@@ -15,6 +15,10 @@ data:
 {{ include (print .Template.BasePath "/etc/_linux-bridge.ini.tpl") . | indent 4 }}
   dnsmasq.conf: |
 {{ include (print .Template.BasePath "/etc/_dnsmasq.conf.tpl") . | indent 4 }}
+{{- if .Values.unbound.enabled }}
+  unbound.conf: |
+{{ include (print .Template.BasePath "/etc/_unbound.conf.tpl") . | indent 4 }}
+{{- end}}
   l3-agent.ini: |
 {{ include (print .Template.BasePath "/etc/_l3-agent.ini.tpl") . | indent 4 }}
   asr1k-global.ini: |

--- a/openstack/neutron/templates/dnstap-secrets.yaml
+++ b/openstack/neutron/templates/dnstap-secrets.yaml
@@ -1,0 +1,10 @@
+{{- if $.Values.dnstap.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.Release.Name}}-hec-secrets
+type: Opaque
+data:
+  hec_splunk_url: {{ required ".Values.dnstap.hec_splunk_url is required if dnstap is enabled." $.Values.dnstap.hec_splunk_url | b64enc }}
+  hec_splunk_token: {{ required ".Values.dnstap.hec_splunk_token is required if dnstap is enabled." $.Values.dnstap.hec_splunk_token | b64enc }}
+{{- end }}

--- a/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
+++ b/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
@@ -17,7 +17,24 @@ num_sync_threads = {{.Values.agent.dhcp.num_sync_threads | default 4 }}
 edns_client_fingerprint = {{.Values.agent.dhcp.edns_client_fingerprint | default "False" }}
 netns_resolvconf = {{.Values.agent.dhcp.netns_resolvconf | default "False" }}
 enable_router_advertisements = {{.Values.agent.dhcp.enable_router_advertisements | default "False" }}
+{{- if and .Values.dhcp_driver .Values.unbound.enabled }}
+dhcp_driver = {{.Values.dhcp_driver}}
+{{- end }}
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 5 }}
 rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}
+
+[SCI]
+dnstap_enabled = {{ .Values.dnstap.enabled | default "False" }}
+{{- if .Values.dnstap.suffix }}
+dnstap_suffix = {{ .Values.dnstap.suffix }}
+{{- else }}
+dnstap_suffix = dnstap.cc.{{ .Values.global.region }}.cloud.sap
+{{- end }}
+{{- if .Values.unbound.logdir }}
+unbound_logdir = {{ .Values.unbound.logdir }}
+{{- end }}
+{{- if .Values.unbound.rpz_ttl }}
+unbound_rpz_ttl = {{ .Values.unbound.rpz_ttl }}
+{{- end }}

--- a/openstack/neutron/templates/etc/_dhcp.filters.tpl
+++ b/openstack/neutron/templates/etc/_dhcp.filters.tpl
@@ -16,6 +16,11 @@ dnsmasq: CommandFilter, dnsmasq, root
 kill_dnsmasq: KillFilter, root, /sbin/dnsmasq, -9, -HUP
 kill_dnsmasq_usr: KillFilter, root, /usr/sbin/dnsmasq, -9, -HUP
 
+{{- if .Values.unbound.enabled -}}
+unbound: CommandFilter, unbound, root
+unbound_env: EnvFilter, env, root, PROCESS_TAG=, unbound
+{{- end }}
+
 ovs-vsctl: CommandFilter, ovs-vsctl, root
 ivs-ctl: CommandFilter, ivs-ctl, root
 mm-ctl: CommandFilter, mm-ctl, root

--- a/openstack/neutron/templates/etc/_unbound.conf.tpl
+++ b/openstack/neutron/templates/etc/_unbound.conf.tpl
@@ -1,0 +1,45 @@
+server:
+    interface: 0.0.0.0@53
+    interface: ::@53
+    root-hints: "/usr/share/dns/root.hints"
+    module-config: "respip iterator"
+    use-syslog: no
+
+    so-reuseport: yes
+    access-control: 0.0.0.0/0 allow
+
+    do-ip4: yes
+    do-ip6: yes
+    do-udp: yes
+    do-tcp: yes
+
+    # use more than one thread
+    num-threads: 4
+
+    # Number of TCP buffers to allocate per thread, default 10.
+    # "For larger installations increasing this value is a good idea."
+    outgoing-num-tcp: 500
+    incoming-num-tcp: 500
+
+    # keep UDP ports around a bit, so late upstream responses 
+    # do not hit a closed port
+    delay-close: 2000
+
+    # limit negative caching, so we pick up new entries faster
+    cache-max-negative-ttl: 60
+
+    # do not cache entries longer than 4 hours.
+    # note that we are using prefetching and serve expired records
+    cache-max-ttl: 14400
+
+    # prefetch cache entries that are about to expire
+    prefetch: yes
+
+    # if a cache TTL is expired and we get a query for it,
+    # first try for 1800ms to resolve
+    serve-expired-client-timeout: 1800
+    # if this fails serve stale records from cache
+    serve-expired: yes
+    # but only for one hour.
+    serve-expired-ttl: 3600
+

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -138,6 +138,10 @@ spec:
               mountPath: /run/dhcp-agent
             - name: metadata-proxy
               mountPath: /run/metadata_proxy
+{{- if $.Values.dnstap.enabled }}
+            - name: dnstap-socket
+              mountPath: {{ $.Values.dnstap.socket_path | default "/run/dnstap/dnstap.sock" | dir }}
+{{- end }}
             - name: modules
               mountPath: /lib/modules
               readOnly: true
@@ -185,6 +189,51 @@ spec:
               subPath: sudoers
               readOnly: true
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
+
+{{- if $.Values.dnstap.enabled }}
+        - name: dnstap
+          image: {{ required "$.Values.global.registryAlternateRegion is missing" $.Values.global.registryAlternateRegion }}/{{$.Values.dnstap.image}}:{{ $.Values.dnstap.image_tag}}
+          imagePullPolicy: {{ $.Values.dnstap.image_pullPolicy }}
+          resources:
+{{- if $.Values.pod.resources.dnstap }}
+{{ toYaml $.Values.pod.resources.dnstap | indent 12 }}
+{{- end }}
+          args:
+            - -u
+            - {{ $.Values.dnstap.socket_path | default "/run/dnstap/dnstap.sock" }}
+{{- if $.Values.dnstap.hec_splunk_url }}
+{{- if $.Values.dnstap.hec_splunk_token }}
+            - -H
+            - "$(HEC_SPLUNK_URL)"
+            - -token
+            - "$(HEC_SPLUNK_TOKEN)"
+{{- if $.Values.dnstap.hec_splunk_server_uuid }}
+            - -server_uuid
+            - {{ $.Values.dnstap.hec_splunk_server_uuid }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $.Values.dnstap.additional_cmdline_args }}
+{{ toYaml $.Values.dnstap.additional_cmdline_args | indent 12 }}
+{{- end }}
+{{- if and $.Values.dnstap.hec_splunk_url $.Values.dnstap.hec_splunk_token }}
+          env:
+          - name: HEC_SPLUNK_URL
+            valueFrom:
+              secretKeyRef:
+                name: {{$.Release.Name}}-hec-secrets
+                key: hec_splunk_url
+          - name: HEC_SPLUNK_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{$.Release.Name}}-hec-secrets
+                key: hec_splunk_token
+{{- end }}
+          volumeMounts:
+            - name: dnstap-socket
+              mountPath: {{ $.Values.dnstap.socket_path | default "/run/dnstap/dnstap.sock" | dir }}
+{{- end }}
+
         - name: agent-check-exporter
           image: {{$.Values.global.registry}}/neutron-network-agent-checks:{{ $.Values.imageVersionAgentExporter | required "Please set neutron.imageVersionAgentExporter "}}
           imagePullPolicy: IfNotPresent
@@ -231,6 +280,11 @@ spec:
           emptyDir: {}
         - name: metadata-proxy
           emptyDir: {}
+{{- if $.Values.dnstap.enabled }}
+        - name: dnstap-socket
+          emptyDir:
+            medium: Memory
+{{- end }}
         - name: modules
           hostPath:
             path: /lib/modules

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -125,6 +125,10 @@ spec:
               mountPath: /run/dhcp-agent
             - name: metadata-proxy
               mountPath: /run/metadata_proxy
+{{- if .Values.dnstap.enabled }}
+            - name: dnstap-socket
+              mountPath: {{ .Values.dnstap.socket_path | default "/run/dnstap/dnstap.sock" | dir }}
+{{- end }}
             - name: modules
               mountPath: /lib/modules
               readOnly: true
@@ -192,6 +196,49 @@ spec:
           volumeMounts:
             - name: network-status
               mountPath: /run/dhcp-agent
+{{- if .Values.dnstap.enabled }}
+        - name: dnstap
+          image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.dnstap.image}}:{{ .Values.dnstap.image_tag}}
+          imagePullPolicy: {{ .Values.dnstap.image_pullPolicy }}
+          resources:
+{{- if .Values.pod.resources.dnstap }}
+{{ toYaml .Values.pod.resources.dnstap | indent 12 }}
+{{- end }}
+          args:
+            - -u
+            - {{ .Values.dnstap.socket_path | default "/run/dnstap/dnstap.sock" }}
+{{- if .Values.dnstap.hec_splunk_url }}
+{{- if .Values.dnstap.hec_splunk_token }}
+            - -H
+            - "$(HEC_SPLUNK_URL)"
+            - -token
+            - "$(HEC_SPLUNK_TOKEN)"
+{{- if .Values.dnstap.hec_splunk_server_uuid }}
+            - -server_uuid
+            - {{ .Values.dnstap.hec_splunk_server_uuid }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.dnstap.additional_cmdline_args }}
+{{ toYaml .Values.dnstap.additional_cmdline_args | indent 12 }}
+{{- end }}
+{{- if and $.Values.dnstap.hec_splunk_url $.Values.dnstap.hec_splunk_token }}
+          env:
+          - name: HEC_SPLUNK_URL
+            valueFrom:
+              secretKeyRef:
+                name: {{.Release.Name}}-hec-secrets
+                key: hec_splunk_url
+          - name: HEC_SPLUNK_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{.Release.Name}}-hec-secrets
+                key: hec_splunk_token
+{{- end }}
+          volumeMounts:
+            - name: dnstap-socket
+              mountPath: {{ .Values.dnstap.socket_path | default "/run/dnstap/dnstap.sock" | dir }}
+{{- end }}
 {{- if $.Values.agent.neutron_l3 | default false }}
         - name: neutron-l3-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentL3 | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentL3 or similar"}}
@@ -307,6 +354,11 @@ spec:
         - name: metadata-proxy
           hostPath:
             path: /run/metadata-proxy
+{{- if .Values.dnstap.enabled }}
+        - name: dnstap-socket
+          emptyDir:
+            medium: Memory
+{{- end }}
         - name : modules
           hostPath:
             path: /lib/modules

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -171,6 +171,10 @@ pod:
       requests:
         cpu: "100m"
         memory: "300Mi"
+    dnstap:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
 
 debug: "True"
 port_metrics: '9102'
@@ -1035,6 +1039,8 @@ dnsmasq:
 
 dnstap:
   enabled: false
+  image: dnstap
+  image_tag: latest
 
 unbound:
   enabled: false

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -1033,6 +1033,12 @@ dnsmasq:
   conf:
     no-negcache: true
 
+dnstap:
+  enabled: false
+
+unbound:
+  enabled: false
+
 memcached:
   alerts:
     support_group: network-api


### PR DESCRIPTION
This allows us to enable unbound in the dhcp-agents and replace the DNS functionality of dnsmasq.