### PR TITLE
feat(cc-gardener/openstack): Enable live resizing of volumes

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.28
+version: 0.38.29
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/managedresources/managedcloudprofile-openstack.yaml
+++ b/global/cc-gardener/managedresources/managedcloudprofile-openstack.yaml
@@ -25,6 +25,9 @@ spec:
     providerConfig:
       apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
       kind: CloudProfileConfig
+      {{- if .Values.extensions.openstack.providerConfig.rescanBlockStorageOnResize }}
+      rescanBlockStorageOnResize: {{ .Values.extensions.openstack.providerConfig.rescanBlockStorageOnResize }}
+      {{- end }}
       keystoneURLs:
       {{- range $region := .Values.extensions.openstack.regions }}
       - region: {{ $region.name | quote }}

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -510,6 +510,7 @@ extensions:
     machineImages: []
     providerConfig:
       machineImages: []
+      rescanBlockStorageOnResize: true
     regions: []
     imageVectorOverwrite:
       images:


### PR DESCRIPTION
## Description
Enables live resizing of volumes in OpenStack CloudProfile by making the `rescanBlockStorageOnResize` configuration parameter templatable in the ManagedCloudProfile.

## Motivation and Context
This change allows volumes to be dynamically resized without requiring a pod restart. The `rescanBlockStorageOnResize` flag ensures that the block storage is rescanned when a resize operation occurs, enabling seamless volume expansion in the Persephone runtime environment.

## Block Storage - cinder-csi-plugin
https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md#block-storage

## Changes
- Added `rescanBlockStorageOnResize` parameter to `global/cc-gardener/managedresources/managedcloudprofile-openstack.yaml`
- Configured via `global/cc-gardener/values.yaml` for flexibility
- Uses conditional templating to include the parameter when configured
- Bumped chart version to 0.38.29