### PR TITLE
feat(cc-shoots): add extraLabels and shootExtraLabels support to all Shoot templates

### DIFF
--- a/system/cc-shoots-compute/Chart.yaml
+++ b/system/cc-shoots-compute/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-compute
 description: Converged Cloud Gardener shoots
 type: application
-version: 2.6.8
+version: 2.6.9
 appVersion: "0.1.0"

--- a/system/cc-shoots-compute/templates/kvm-shoot.yaml
+++ b/system/cc-shoots-compute/templates/kvm-shoot.yaml
@@ -10,6 +10,9 @@ metadata:
     greenhouse.sap/owned-by: compute
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ coalesce $.Values.contextSuffix $cluster.region }}
+    {{- with merge (default dict $cluster.extraLabels) (default dict $.Values.shootExtraLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:

--- a/system/cc-shoots-controlplane/Chart.yaml
+++ b/system/cc-shoots-controlplane/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-controlplane
 description: Converged Cloud Gardener Controlplane shoots
 type: application
-version: 1.0.10
+version: 1.0.11
 appVersion: "0.1.0"

--- a/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
+++ b/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
@@ -9,6 +9,9 @@ metadata:
     greenhouse.sap/owned-by: containers
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ $key }}
+    {{- with merge (default dict $cluster.extraLabels) (default dict $.Values.shootExtraLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:

--- a/system/cc-shoots-mgmt/Chart.yaml
+++ b/system/cc-shoots-mgmt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-mgmt
 description: Converged Cloud Gardener shoots
 type: application
-version: 1.1.42
+version: 1.1.43
 appVersion: "0.1.0"

--- a/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
+++ b/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
@@ -11,6 +11,9 @@ metadata:
     greenhouse.sap/owned-by: containers
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ $key }}
+    {{- with merge (default dict $cluster.extraLabels) (default dict $.Values.shootExtraLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:

--- a/system/cc-shoots-storage/Chart.yaml
+++ b/system/cc-shoots-storage/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-storage
 description: Converged Cloud Gardener Storage shoots
 type: application
-version: 0.0.15
+version: 0.0.16
 appVersion: "0.1.0"

--- a/system/cc-shoots-storage/templates/storage-shoot.yaml
+++ b/system/cc-shoots-storage/templates/storage-shoot.yaml
@@ -9,6 +9,9 @@ metadata:
     cluster-type: sci-k8s-storage
     greenhouse.sap/owned-by: storage
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
+    {{- with merge (default dict $cluster.extraLabels) (default dict $.Values.shootExtraLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:

--- a/system/cc-shoots-workerless/Chart.yaml
+++ b/system/cc-shoots-workerless/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-workerless
 description: Converged Cloud Gardener Workerless Shoots
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "0.1.0"

--- a/system/cc-shoots-workerless/templates/shoot-workerless.yaml
+++ b/system/cc-shoots-workerless/templates/shoot-workerless.yaml
@@ -13,6 +13,9 @@ metadata:
     greenhouse.sap/owned-by: {{ $supportGroup }}
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ $regionName }}
+    {{- with merge (default dict $cluster.extraLabels) (default dict $.Values.shootExtraLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:

--- a/system/cc-shoots/Chart.yaml
+++ b/system/cc-shoots/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots
 description: Converged Cloud Gardener shoots
 type: application
-version: 0.7.4
+version: 0.7.5
 appVersion: "0.1.0"

--- a/system/cc-shoots/templates/metal-shoot.yaml
+++ b/system/cc-shoots/templates/metal-shoot.yaml
@@ -11,6 +11,9 @@ metadata:
     greenhouse.sap/owned-by: containers
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ $regionName }}
+    {{- with merge (default dict $region.extraLabels) (default dict $.Values.shootExtraLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   purpose: {{ default "production" $region.purpose }}
   cloudProfile:


### PR DESCRIPTION
## Summary

Add two levels of optional extra labels on Shoot `metadata.labels` across all 6 `cc-shoot*` charts:

- **`shootExtraLabels`** (top-level values) — applies to all Shoots in the deployment
- **`extraLabels`** (per-cluster/region entry) — per-shoot labels, merged with `shootExtraLabels` (per-cluster wins on conflict)

When neither is set, no extra labels are rendered — zero behavioral change.

## Motivation

Enable labeling specific clusters with regulatory labels from downstream values, targeting only specific region clusters.

## Charts changed

| Chart | Version bump | Template |
|---|---|---|
| `cc-shoots` | 0.7.4 → 0.7.5 | `metal-shoot.yaml` |
| `cc-shoots-compute` | 2.6.8 → 2.6.9 | `kvm-shoot.yaml` |
| `cc-shoots-controlplane` | 1.0.10 → 1.0.11 | `controlplane-shoot.yaml` |
| `cc-shoots-mgmt` | 1.1.42 → 1.1.43 | `mgmt-shoot.yaml` |
| `cc-shoots-storage` | 0.0.15 → 0.0.16 | `storage-shoot.yaml` |
| `cc-shoots-workerless` | 0.0.6 → 0.0.7 | `shoot-workerless.yaml` |

## Usage

Per-cluster (targets specific shoots):
```yaml
# cc-shoots values
regions:
  my-region:
    extraLabels:
      my-label: my-value

# cc-shoots-compute values
kvmShoots:
  my-cluster:
    extraLabels:
      my-label: my-value

# cc-shoots-workerless values (lighthouse/wireapi)
clusters:
  my-cluster:
    extraLabels:
      my-label: my-value
```

Top-level (all shoots in deployment):
```yaml
shootExtraLabels:
  my-label: my-value
```