### PR TITLE
all srs: use utils chart for rendering internal OS_AUTH_URL

### DIFF
--- a/openstack/castellum/Chart.lock
+++ b/openstack/castellum/Chart.lock
@@ -14,5 +14,8 @@ dependencies:
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:32cc6301702ed06ba883cace3884453da32e76c9e3a52c426c1809634df7119e
-generated: "2026-08-27T13:28:34.701173947Z"
+- name: utils
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.38.1
+digest: sha256:a668eeda4371d8407158d14e318390111537373058f4dbfc51fb1c0898093b91
+generated: "2026-08-27T15:30:01.593257716+02:00"

--- a/openstack/castellum/Chart.yaml
+++ b/openstack/castellum/Chart.yaml
@@ -19,3 +19,6 @@ dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'
+  - name: utils
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/openstack/castellum/templates/_utils.tpl
+++ b/openstack/castellum/templates/_utils.tpl
@@ -60,7 +60,7 @@
   value: /etc/castellum-certs/prometheus-vmware.key.pem
 {{- end }}
 - name: OS_AUTH_URL
-  value: "http://keystone.{{ .Values.global.keystoneNamespace }}.svc.{{ .Values.global.clusterDNSSearchDomain }}:5000/v3"
+  value: "{{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3"
 - name: OS_AUTH_VERSION
   value: "3"
 - name: OS_IDENTITY_API_VERSION

--- a/openstack/keppel/Chart.lock
+++ b/openstack/keppel/Chart.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: shared-app-images-tags
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.662
-digest: sha256:5b60a849a6042db00d7fc21cdb7bc56f8b62dc3e2720f8e447d5da4bba90fd9f
-generated: "2026-08-27T13:28:58.004279222Z"
+- name: utils
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.38.1
+digest: sha256:66ecd12d2bacfe1a0fd605d64a4fd24c4dda57dbd1f0119a407a50d01edc95c4
+generated: "2026-08-27T15:30:03.622118338+02:00"

--- a/openstack/keppel/Chart.yaml
+++ b/openstack/keppel/Chart.yaml
@@ -25,3 +25,6 @@ dependencies:
   - name: shared-app-images-tags
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'
+  - name: utils
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/openstack/keppel/templates/_utils.tpl
+++ b/openstack/keppel/templates/_utils.tpl
@@ -128,7 +128,7 @@
       name: keppel-secret
       key: trivy_token
 - name:  OS_AUTH_URL
-  value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.{{ $.Values.global.clusterDNSSearchDomain }}:5000/v3"
+  value: "{{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3"
 - name:  OS_AUTH_VERSION
   value: '3'
 - name:  OS_IDENTITY_API_VERSION

--- a/openstack/keppel/templates/deployment-health-monitor.yaml
+++ b/openstack/keppel/templates/deployment-health-monitor.yaml
@@ -32,7 +32,7 @@ spec:
             - name:  KEPPEL_DEBUG
               value: 'false'
             - name: OS_AUTH_URL
-              value: "http://keystone.{{ .Values.global.keystoneNamespace }}.svc.{{ .Values.global.clusterDNSSearchDomain }}:5000/v3"
+              value: "{{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3"
             - name:  OS_AUTH_VERSION
               value: '3'
             - name:  OS_IDENTITY_API_VERSION

--- a/openstack/limes-campfire/Chart.lock
+++ b/openstack/limes-campfire/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:7b0dbbfbf5e291ac2cfd0ad02125c92f96c4804640ef6e4866cd9375f25d700d
-generated: "2025-08-06T11:47:50.031795043Z"
+- name: utils
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.38.1
+digest: sha256:7f9f1791a1d6cb57d602f7bd00cf5c062a4fafcc5d168c05f189ffa94711936a
+generated: "2026-08-27T15:30:06.658666213+02:00"

--- a/openstack/limes-campfire/Chart.yaml
+++ b/openstack/limes-campfire/Chart.yaml
@@ -9,3 +9,6 @@ dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'
+  - name: utils
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/openstack/limes-campfire/templates/deployment.yaml
+++ b/openstack/limes-campfire/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               value: "https://{{ contains "qa" $dbRegion | ternary "identity-3-qa" "identity-3" }}.global.{{ $tld }}/v3"
             {{- else }}
             - name: OS_AUTH_URL
-              value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.{{ $.Values.global.clusterDNSSearchDomain }}:5000/v3"
+              value: "{{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3"
             {{- end }}
             - name: OS_USER_DOMAIN_NAME
               value: Default

--- a/openstack/limes/Chart.lock
+++ b/openstack/limes/Chart.lock
@@ -14,5 +14,8 @@ dependencies:
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:32cc6301702ed06ba883cace3884453da32e76c9e3a52c426c1809634df7119e
-generated: "2026-08-27T13:29:16.075810903Z"
+- name: utils
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.38.1
+digest: sha256:a668eeda4371d8407158d14e318390111537373058f4dbfc51fb1c0898093b91
+generated: "2026-08-27T15:30:05.579113081+02:00"

--- a/openstack/limes/Chart.yaml
+++ b/openstack/limes/Chart.yaml
@@ -19,3 +19,6 @@ dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'
+  - name: utils
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/openstack/limes/templates/_utils.tpl
+++ b/openstack/limes/templates/_utils.tpl
@@ -50,7 +50,7 @@
   value: "public"
 {{- else }}
 - name: OS_AUTH_URL
-  value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.{{ $.Values.global.clusterDNSSearchDomain }}:5000/v3"
+  value: "{{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3"
 - name: OS_INTERFACE
   value: "internal"
 {{- end }}


### PR DESCRIPTION
The current hardcoded pattern (`http://keystone.$NAMESPACE.svc.$SEARCH_DOMAIN:5000/v3`) will become incorrect when Keystone and Barbican move into a different namespace/cluster in certain regions because of regulatory requirements. By relying on the logic in openstack/utils, we will be dragged along when upstream changes the utils chart accordingly.

The new form looks slightly convoluted, but I'm following past precedent from other OpenStack charts for maximum compatibility.

**Draft:** openstack/utils is broken because it assumes that `.Release.Namespace == "monsoon3"`. Therefore, this changeset results in tons of incorrect diffs like:

```
$ h diff upgrade -C 5 keppel helm-charts.git/openstack/keppel --namespace keppel --reset-values --normalize-manifests --find-renames 0.2 ...
keppel, keppel-api, Deployment (apps) has changed:
...
            valueFrom:
              secretKeyRef:
                key: trivy_token
                name: keppel-secret
          - name: OS_AUTH_URL
-           value: http://keystone.monsoon3.svc.<REDACTED>:5000/v3
+           value: http://keystone.keppel.svc.<REDACTED>:5000/v3
          - name: OS_AUTH_VERSION
            value: "3"
          - name: OS_IDENTITY_API_VERSION
            value: "3"
          - name: OS_INTERFACE
...
```