### PR TITLE
feat(persephone-runtime-shoot): add extraLabels and shootExtraLabels support

### DIFF
--- a/global/persephone-runtime-shoot/Chart.yaml
+++ b/global/persephone-runtime-shoot/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: persephone-runtime-shoot
 description: Persephone Runtime Shoot
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "0.1.0"

--- a/global/persephone-runtime-shoot/templates/runtime-shoot.yaml
+++ b/global/persephone-runtime-shoot/templates/runtime-shoot.yaml
@@ -6,6 +6,9 @@ metadata:
     cluster-type: {{ required "missing value for .Values.clusterType" .Values.clusterType }}
     greenhouse.sap/shoot-grafter-transport: {{ required "missing value for .Values.greenhouseShootGrafter" .Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ required "missing value for .Values.global.region" .Values.global.region }}
+    {{- with merge (default dict .Values.extraLabels) (default dict .Values.shootExtraLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   cloudProfile:
     kind: CloudProfile


### PR DESCRIPTION
## Summary

Add two levels of optional extra labels on Shoot `metadata.labels` for `persephone-runtime-shoot`:

- **`extraLabels`** (top-level values) — per-shoot labels
- **`shootExtraLabels`** (top-level values) — applies to all shoots, merged with `extraLabels` (`extraLabels` wins on conflict)

When neither is set, no extra labels are rendered — zero behavioral change.

## Motivation

Same as #12682 — enable labeling specific clusters with regulatory labels from downstream values.

## Charts changed

| Chart | Version bump | Template |
|---|---|---|
| `persephone-runtime-shoot` | 0.1.10 → 0.1.11 | `runtime-shoot.yaml` |

## Usage

```yaml
extraLabels:
  my-label: my-value
```

Or global (all shoots):
```yaml
shootExtraLabels:
  my-label: my-value
```