### PR TITLE
[cinder] add --single-child to dumb-init for backup pods

### DIFF
--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -88,6 +88,7 @@ template: |
               - CHOWN
           command:
           - dumb-init
+          - --single-child
           - cinder-backup
           env:
           {{- if .Values.sentry.enabled }}


### PR DESCRIPTION
Without `--single-child`, `dumb-init` sends SIGTERM to the entire process group. The ProcessLauncher parent exits before backup children finish draining in-flight operations (e.g., backup restore), and the kernel SIGKILLs the remaining processes.

With `--single-child`, `dumb-init` forwards SIGTERM only to the ProcessLauncher parent, which then forwards to each child and waits for all children to exit.

This matches the cinder-volume VMware deployment (added in #11680) and is required for the graceful shutdown feature (sapcc/cinder#358).

### What changed

One line added to `backup_deployment.yaml`:
```yaml
command:
- dumb-init
- --single-child   # <-- added
- cinder-backup
```

### Background

During Antelope testing of the graceful shutdown feature, we discovered that `dumb-init` without `--single-child` broadcasts SIGTERM to the entire process group, causing premature container exit. PR #11680 fixed this for cinder-volume VMware pods but the backup deployment was missed. This PR closes that gap.

### Risk

None — `--single-child` only changes signal forwarding behavior (SIGTERM to direct child only instead of process group). No functional change to backup operations. Safe to deploy without the graceful shutdown cinder code change.

Supersedes the backup portion of #10305 (which proposed dropping dumb-init entirely but is stale/conflicts with master).