### PR TITLE
[cinder] Pass terminationGracePeriodSeconds to CinderNetappConfig CR for KVM pods

### DIFF
--- a/openstack/cinder/templates/cindernetappconfig.yaml
+++ b/openstack/cinder/templates/cindernetappconfig.yaml
@@ -24,6 +24,7 @@ spec:
   proxysqlmodepresent: {{ if .Values.proxysql.mode }}true{{ else }}false{{ end }}
   proxysqlnativesidecar: {{required ".Values.proxysql.native_sidecar is missing" .Values.proxysql.native_sidecar}}
   linkerdenabled: {{ if and .Values.global.linkerd_enabled .Values.global.linkerd_requested }}true{{ else }}false{{ end }}
+  terminationgraceperiodseconds: {{ .Values.pod.terminationGracePeriodSeconds.volume }}
   manageserviceuserpasswords: {{required ".Values.manage_service_user_passwords is missing" .Values.manage_service_user_passwords}}
   {{- if .Values.rbac.enabled }}
   serviceaccountname: {{ .Release.Name }}


### PR DESCRIPTION
The `kvm-cinder-netapp-operator` CRD already supports the `terminationgraceperiodseconds` field (verified live in qa-de-1), but the Helm chart was not populating it. KVM cinder-volume pods were getting the Kubernetes default of 30s, while VMware volume and backup pods get 900s.

### Problem

Measured in qa-de-1:

| Pod type | terminationGracePeriodSeconds |
|----------|------------------------------|
| VMware volume (`cinder-volume-vmware-vc-*`) | 900 |
| VMware backup (`cinder-volume-backup-vmware-vc-*`) | 900 |
| **KVM volume (`cinder-volume-kvm-*`)** | **30** |

With 30s, any in-flight KVM volume operation taking longer than 30 seconds (e.g., volume create from image, migration) will be SIGKILLed by Kubernetes during pod shutdown.

### Fix

One line added to `cindernetappconfig.yaml` to pass `pod.terminationGracePeriodSeconds.volume` into the `CinderNetappConfig` CR:

```yaml
terminationgraceperiodseconds: {{ .Values.pod.terminationGracePeriodSeconds.volume }}
```

The value defaults to 30 in `values.yaml` and is overridden to 900 per region in secrets (e.g., `qa-de-1/values/cinder.yaml` already sets `pod.terminationGracePeriodSeconds.volume: 900`).

### No secrets change needed

The secrets already set `volume: 900` — the value just wasn't being passed to the operator CR.

### Required for

Graceful shutdown feature: sapcc/cinder#358

### Related

- #12685 — adds `--single-child` to dumb-init for backup pods (same graceful shutdown prerequisite)
- #11680 — added `dumb-init --single-child` for VMware volume pods