### PR TITLE
codeowners: add compute API team for glance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,7 +79,7 @@
 /openstack/designate                                   @galkindmitrii @fwiesel @mutax @kpawar-sap @vssldmtrv @proddi @mbrowny @SoenkeL @occamshatchet
 /openstack/designate-nanny                             @mutax @vssldmtrv @proddi @mbrowny @SoenkeL @galkindmitrii @occamshatchet
 /openstack/elektra                                     @andypf @edda @ArtieReus @hgw77
-/openstack/glance                                      @rajivmucheli @seb-kro @Scsabiii @stefanhipfel
+/openstack/glance                                      @rajivmucheli @Scsabiii @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @bzzybriel @mchristianl @anokfireball
 /openstack/grafanasix                                  @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo # old
 /openstack/hermes                                      @notque @LeoZhangZXZ @Kuckkuck @notandy @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old


### PR DESCRIPTION
Glance is now maintained by the compute API team. Add team members and remove Stefan Hipfel who is no longer actively involved.