### PR TITLE
[archer] set idle_in_transaction_session_timeout for archer db role

### DIFF
--- a/openstack/archer/values.yaml
+++ b/openstack/archer/values.yaml
@@ -19,7 +19,9 @@ postgresql:
   alerts:
     support_group: containers
   databases:
-    archer: {}
+    archer:
+      sqlOnStartup: |
+        ALTER ROLE archer SET idle_in_transaction_session_timeout = '5min';
   extensions:
     pgcrypto: []
   persistence:


### PR DESCRIPTION
Sets `idle_in_transaction_session_timeout = '5min'` for the archer PostgreSQL role via `sqlOnStartup`, preventing idle transactions from holding locks indefinitely.