### PR TITLE
fix(cc-gardener): gate extension-aws behind enabled flag

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.30
+version: 0.38.31
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/templates/extension-aws.yaml
+++ b/global/cc-gardener/templates/extension-aws.yaml
@@ -1,5 +1,5 @@
 # The runtime values always need to be enabled to manage backups in s3 for the virtual garden.
-{{ if eq .Values.garden.backup.provider "aws" -}}
+{{ if and .Values.extensions.aws.enabled (eq .Values.garden.backup.provider "aws") -}}
 {{- with .Values.extensions.aws -}}
 apiVersion: operator.gardener.cloud/v1alpha1
 kind: Extension

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -331,6 +331,7 @@ extensions:
     parameters: {}
   kubernetesVersions: []
   aws:
+    enabled: true
     version: v1.70.0
     values:
       image:


### PR DESCRIPTION
## Summary

All other extensions (openstack, calico, gardenlinux, metal, networking-problem-detector, oidc-apps-controller) use `.extensions.<name>.enabled` to control whether the `Extension` resource is rendered.

The AWS extension was the only outlier — it used `garden.backup.provider == "aws"` instead.

This PR aligns `extension-aws.yaml` with the common pattern.

## Changes

- **`extension-aws.yaml`** — replace `{{ if eq .Values.garden.backup.provider "aws" }}` with `{{ if .Values.extensions.aws.enabled }}`
- **`values.yaml`** — add `enabled: false` default under `extensions.aws`
- **`Chart.yaml`** — version bump `0.38.30` → `0.38.31`

## Action required

Region/environment value overrides that previously relied on `garden.backup.provider: aws` to implicitly enable this extension now need:

```yaml
extensions:
  aws:
    enabled: true
```