### PR TITLE
barbican: fix Apache double-logging and shell quoting

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.9.1
+version: 0.9.2
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/templates/bin/_barbican_api.sh.tpl
+++ b/openstack/barbican/templates/bin/_barbican_api.sh.tpl
@@ -6,7 +6,7 @@ COMMAND="${@:-start}"
 
 function start () {
   for BARBICAN_WSGI_SCRIPT in barbican-wsgi-api; do
-    cp -a $(type -p ${BARBICAN_WSGI_SCRIPT}) /var/www/cgi-bin/barbican/
+    cp -a "$(type -p "${BARBICAN_WSGI_SCRIPT}")" /var/www/cgi-bin/barbican/
   done
 
   if [ -f /etc/apache2/envvars ]; then
@@ -29,4 +29,4 @@ function stop () {
   apachectl -k graceful-stop
 }
 
-$COMMAND
+"$COMMAND"

--- a/openstack/barbican/templates/etc/_wsgi-barbican.conf.tpl
+++ b/openstack/barbican/templates/etc/_wsgi-barbican.conf.tpl
@@ -5,16 +5,10 @@ ErrorLog /dev/stdout
 ErrorLogFormat "%M"
 LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%a\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_combined
 LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%{X-Forwarded-For}i\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_proxy
-SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
-CustomLog /dev/stdout json_combined env=!forwarded
-CustomLog /dev/stdout json_proxy env=forwarded
 {{- else }}
 ErrorLog /dev/stderr
 LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %h %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %{X-Forwarded-For}i %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"" proxy
-SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
-CustomLog /dev/stdout combined env=!forwarded
-CustomLog /dev/stdout proxy env=forwarded
 {{- end }}
 
 WSGIDaemonProcess barbican-api processes={{ .Values.api.processes | default 1 }} threads={{ .Values.api.threads | default 1 }} \


### PR DESCRIPTION
Follow-up to #12554 / #12590 — fixing two issues found in post-merge review.

## Changes

**Fix: Apache double-logging** (`_wsgi-barbican.conf.tpl`)

Server-level `SetEnvIf` + `CustomLog` directives were present alongside the same directives inside `<VirtualHost>`. Apache log model is additive: server-level `CustomLog` fires for all requests AND the VirtualHost adds to it. Since `sites-enabled` is masked with an emptyDir every request was logged twice.

`LogFormat` definitions remain global (required). `SetEnvIf` and `CustomLog` now live only inside `<VirtualHost>`.

**Fix: shell quoting** (`_barbican_api.sh.tpl`)

- `cp -a $(type -p ${BARBICAN_WSGI_SCRIPT})` → quoted: if the WSGI script is missing from PATH the unquoted form passes an empty arg to `cp`, which silently succeeds, then Apache starts with an empty WSGI dir and the pod crash-loops. Quoted form fails fast at `cp`.
- `$COMMAND` → `"$COMMAND"`: consistency with `set -ex`.

## Test plan
- [ ] Single access log line per request in pod logs (was: two identical lines)
- [ ] Pod rolling restart completes cleanly