### PR TITLE
keppel-auto: lift restriction on anonymous_first_pull RBAC policies

### DIFF
--- a/openstack/keppel-auto/templates/configmap-managed-accounts.yaml
+++ b/openstack/keppel-auto/templates/configmap-managed-accounts.yaml
@@ -28,10 +28,7 @@ accounts:
 
     rbac_policies:
       {{- range $policy := $account.rbac_policies }}
-      {{- $only_valid_on_primary := $policy.permissions | has "anonymous_first_pull" }}
-      {{- if or $is_primary (not $only_valid_on_primary) }}
       - {{ toJson $policy }}
-      {{- end }}
       {{- end }}
 
     {{- if and $is_primary $account.replication }}


### PR DESCRIPTION
Following https://github.com/sapcc/keppel/pull/780, all RBAC policies can now be applied both on primary and replica accounts.