### PR TITLE
[hermes] feat(log-router): add kafkaForwarding configuration

### DIFF
--- a/openstack/hermes/templates/log-router-configmap.yaml
+++ b/openstack/hermes/templates/log-router-configmap.yaml
@@ -27,4 +27,9 @@ data:
   LOG_ROUTER_S3_PREFIX: {{ .Values.logRouter.s3.prefix | quote }}
   LOG_ROUTER_SWIFT_ENABLED: {{ .Values.logRouter.swift.enabled | quote }}
   LOG_ROUTER_SWIFT_SERVICE_TYPE: {{ .Values.logRouter.swift.service_type | quote }}
+{{- if .Values.logRouter.kafkaForwarding.enabled }}
+  LOG_ROUTER_KAFKA_FORWARDING_BROKERS: {{ required ".Values.logRouter.kafkaForwarding.brokers must be set when kafkaForwarding.enabled=true" .Values.logRouter.kafkaForwarding.brokers | quote }}
+  LOG_ROUTER_KAFKA_FORWARDING_TOPIC: {{ required ".Values.logRouter.kafkaForwarding.topic must be set when kafkaForwarding.enabled=true" .Values.logRouter.kafkaForwarding.topic | quote }}
+  LOG_ROUTER_KAFKA_FORWARDING_TLS: {{ .Values.logRouter.kafkaForwarding.tls | quote }}
+{{- end }}
 {{- end }}

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -264,6 +264,12 @@ logRouter:
   wal:
     storage: 10Gi
 
+  kafkaForwarding:
+    enabled: false
+    brokers: ""
+    topic: ""
+    tls: false
+
   resources:
     requests:
       memory: "256Mi"


### PR DESCRIPTION
## Summary

- Adds `logRouter.kafkaForwarding` block to `values.yaml` (disabled by default): `enabled`, `brokers`, `topic`, `tls`
- Adds a conditional block in `log-router-configmap.yaml` that injects `LOG_ROUTER_KAFKA_FORWARDING_BROKERS`, `LOG_ROUTER_KAFKA_FORWARDING_TOPIC`, and `LOG_ROUTER_KAFKA_FORWARDING_TLS` when `kafkaForwarding.enabled=true`
- Uses `required` guards so a deployment with `enabled=true` but missing `brokers`/`topic` fails at render time

## No other template changes needed

TLS with a public CA (fortlogs broker) requires no mounted Secret files — the env var `LOG_ROUTER_KAFKA_FORWARDING_TLS: "true"` instructs log-router to use system root CAs.

## Related

- log-router code change: SAP-cloud-infrastructure/log-router#42
- Activated for qa-de-1 via the accompanying secrets PR