### PR TITLE
system/edith: add storage_awx agent configuration

### DIFF
--- a/system/edith/templates/configmap.yaml
+++ b/system/edith/templates/configmap.yaml
@@ -58,6 +58,9 @@ data:
         internal_url: {{ .Values.edith.agents.prometheus.internal_url }}
       rag:
         sci_ops_docs: {{ .Values.edith.agents.rag.sci_ops_docs }}
+      storage_awx:
+        awx_base_url: {{ .Values.edith.agents.storage_awx.awx_base_url }}
+        awx_token: {{ .Values.edith.agents.storage_awx.awx_token }}
     prometheus:
       key: |-
         {{ .Values.edith.prometheus.key | nindent 8 }}

--- a/system/edith/values.yaml
+++ b/system/edith/values.yaml
@@ -62,6 +62,9 @@ edith:
       internal_url: DEFINED-IN-REGION-SECRETS
     rag:
       sci_ops_docs: DEFINED-IN-REGION-SECRETS
+    storage_awx:
+      awx_base_url: DEFINED-IN-REGION-SECRETS
+      awx_token: DEFINED-IN-REGION-SECRETS
   prometheus:
     key: |-
       DEFINED-IN-REGION-SECRETS


### PR DESCRIPTION
Expose AWX base URL and token for the storage_awx agent via Helm values and ConfigMap so region secrets can supply them at deploy time. for EDITH