### PR TITLE
[bind] allow using named templates to set up the secret env

### DIFF
--- a/system/bind/templates/_helpers.tpl
+++ b/system/bind/templates/_helpers.tpl
@@ -36,9 +36,30 @@ used by envFrom.secretRef.
 {{- define "setup_secret_env" -}}
 {{- if . }}
 {{- range . }}
+{{- if .value }}
 {{ .name }}: {{ .value | include "resolve_secret" | b64enc }}
+{{- else if .template }}
+{{ .name }}: {{ include .template.name .template.params | b64enc }}
+{{- end }}
 {{- end }}
 {{- else }}
 {}
 {{- end }}
+{{- end }}
+
+{{/*
+Create an rndc/tsig key block
+*/}}
+{{- define "key" -}}
+key "{{.keyname}}" {
+ algorithm "{{.algo}}";
+ secret "{{.secret}}";
+};
+{{- end }}
+
+{{/*
+base64 encode an rndc/tsig key block
+*/}}
+{{- define "base64_key" -}}
+{{ include "key" . | b64enc }}
 {{- end }}


### PR DESCRIPTION
Also, defined two named templates:
```
- key                    # generates a tsig/rndc key block
- base64_key             # base64 encodes that block
```

Currently we only support the following:
```yaml
secret_env:
- name: tsig-key
  value: foobar-base64   # this must be the whole block, prepared, base64 encoded and stored in, say, vault
```

Going forward we'd be able to be more flexible:
```yaml
- name: tsig-key
  template:
    name: base64_key     # this is the named template that will generate the base64 encoded tsig/rndc key block
    params:              # and the params passed to the template
      keyname: <keyname>
      algo:    <algo>
      secret:  <secret>
```