### PR TITLE
ironic: support conductor groups with configurable replicas

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -17,10 +17,17 @@ metadata:
     secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
     deployment.reloader.stakater.com/pause-period: "60s"
 spec:
-  replicas: 1
+  replicas: {{ $conductor.replicas | default 1 }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}
   strategy:
+  {{- if gt (int ($conductor.replicas | default 1)) 1 }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  {{- else }}
     type: Recreate
+  {{- end }}
   selector:
     matchLabels:
     {{- if $conductor.name }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -181,6 +181,7 @@ conductor:
     port: 8088
     erase_devices_priority: 0
   defaults:
+    replicas: 2
     default:
       enabled_hardware_types: ipmi, idrac, redfish
       enabled_boot_interfaces: pxe, ipxe, idrac-redfish-virtual-media, redfish-virtual-media


### PR DESCRIPTION
## Summary

- Add `replicas` support to conductor deployments — defaults to 2 (HA) via `conductor.defaults.replicas`
- Switch deployment strategy to `RollingUpdate` when replicas > 1, so restarting one pod in a group doesn't take the whole group offline
- Keep `kos_conductor: true` as the global default — all regions continue to work with kos unchanged; regions opt in to the static `conductor.hosts` path by setting `kos_conductor: false`

## Test plan

- [ ] Verify existing regions (kos_conductor: true) are unaffected — helm diff should show no changes
- [ ] Set `kos_conductor: false` in qa-de-1 and verify conductor deployments render from `conductor.hosts` with 2 replicas and RollingUpdate strategy
- [ ] Verify a conductor with `replicas: 1` (e.g. tempest) still gets `Recreate` strategy