### PR TITLE
cc-gardener: make oidc-apps-controller issuer and clientId overridable

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.36
+version: 0.38.37
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/templates/extension-oidc-apps-controller.yaml
+++ b/global/cc-gardener/templates/extension-oidc-apps-controller.yaml
@@ -17,7 +17,7 @@ spec:
         cacheSelectorStr: observability.gardener.cloud/app in (plutono, prometheus-shoot,
           alertmanager-seed, alertmanager-shoot)
         clients:
-        - clientId: {{ $.Values.garden.dashboard.oidc.clientIDPublic }}
+        - clientId: {{ .oidcClientId | default $.Values.garden.dashboard.oidc.clientIDPublic }}
           name: oidc-apps-controller-users
         global:
           istioGateway:
@@ -27,7 +27,7 @@ spec:
           oauth2Proxy:
             insecureOidcSkipIssuerVerification: false
             insecureOidcSkipNonce: false
-            oidcIssuerUrl: {{ $.Values.garden.dashboard.oidc.issuerURL }}
+            oidcIssuerUrl: {{ .oidcIssuerUrl | default $.Values.garden.dashboard.oidc.issuerURL }}
             scope: openid email groups
             sslInsecureSkipVerify: false
         priorityClass:

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -431,6 +431,10 @@ extensions:
   oidcAppsController:
     operatorGroups: []
     version: v0.28.0
+    # oidcIssuerUrl and oidcClientId override garden.dashboard.oidc.issuerURL / clientIDPublic
+    # when set. Use a shared audience (e.g. "shoot-observability") for all targets.
+    oidcIssuerUrl: ""
+    oidcClientId: ""
     values:
       replicaCount: 1
       image:


### PR DESCRIPTION
Add oidcIssuerUrl and oidcClientId to extensions.oidcAppsController values so the OIDC issuer and audience can be set independently of the dashboard OIDC config. Falls back to garden.dashboard.oidc.issuerURL / clientIDPublic when not set, preserving existing behavior.

Enables use of the virtual garden kube-apiserver as OIDC issuer with a shared audience (e.g. "shoot-observability") for TokenRequest-based seamless access to shoot monitoring endpoints.