### PR TITLE
remove cfm leftovers

### DIFF
--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.18
+version: 0.2.19
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/ironic/templates/seed.yaml
+++ b/openstack/ironic/templates/seed.yaml
@@ -657,7 +657,6 @@ spec:
   # cc3test does not get seeds
   # ccadmin gets role assignments for the master project and some additional project assignments
   # monsoon3 gets a special role assignment for cc-demo project
-  # s4 gets a special role assignment for S4_CFM_ADMINS group
   # iaas is excluded completely
 
   domains:
@@ -710,13 +709,6 @@ spec:
       role_assignments:
       - project: cc-demo
         role: baremetal_admin
-    {{- end }}
-    {{- if eq . "s4"}}
-    - name: S4_CFM_ADMINS
-      role_assignments:
-      - domain: s4
-        role: cloud_baremetal_admin
-        inherited: true
     {{- end }}
     - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
       role_assignments:

--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.38.1
+version: 0.38.2

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -349,8 +349,6 @@ Custom DB URL for the global services using percona_cluster
 
 {{define "swift_endpoint_host"}}objectstore-3.{{ include "host_fqdn" . }}{{end}}
 
-{{define "cfm_api_endpoint_host_public"}}cfm.{{ include "host_fqdn" . }}{{end}}
-
 {{define "sftp_api_endpoint_host"}}sftp-bridge.{{ .Values.global.region }}.{{ .Values.global.tld }}{{end}}
 
 {{ define "f5_url" }}

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.11.7
+version: 4.11.8
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -98,9 +98,6 @@ prober-static-alt-region:
   prometheusName: kubernetes
 
 http-keep-alive-monitor:
-  alert:
-    ignore_ingress_names:
-      - cfm
   image:
     repository: keppel.global.cloud.sap/ccloud/http-keep-alive-monitor
 


### PR DESCRIPTION
cfm as service was decommisioned years ago so we now remove these leftovers that
are still around.
