### PR TITLE
fix(kubernikus): bump operator image on admin-k3s and metal to fix etcd safe_guard issue

### DIFF
--- a/system/kubernikus-admin-k3s/Chart.yaml
+++ b/system/kubernikus-admin-k3s/Chart.yaml
@@ -18,7 +18,7 @@ version: 2.0.50
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-#appVersion: 1.16.0
+# appVersion: 1.16.0
 dependencies:
   - name: kubernikus
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/kubernikus-admin-k3s/Chart.yaml
+++ b/system/kubernikus-admin-k3s/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.49
+version: 2.0.50
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/system/kubernikus-admin-k3s/values.yaml
+++ b/system/kubernikus-admin-k3s/values.yaml
@@ -1,5 +1,5 @@
 kubernikus:
-  imageTag: 30cacd446fdb3abe27118c5c85e9510a18999bd3
+  imageTag: 612781f18f839c8437b9b52b50adde2980493242
   image: keppel.global.cloud.sap/ccloud/kubernikus
 
   #use a dedicated serviceaccount and proper RBAC rules for this deployment

--- a/system/kubernikus-admin-k3s/values.yaml
+++ b/system/kubernikus-admin-k3s/values.yaml
@@ -2,7 +2,7 @@ kubernikus:
   imageTag: 612781f18f839c8437b9b52b50adde2980493242
   image: keppel.global.cloud.sap/ccloud/kubernikus
 
-  #use a dedicated serviceaccount and proper RBAC rules for this deployment
+  # use a dedicated serviceaccount and proper RBAC rules for this deployment
   standalone: false
   useServiceAccount: true
   includeRBAC: true

--- a/system/kubernikus-metal/Chart.yaml
+++ b/system/kubernikus-metal/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.46
+version: 2.0.47
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/system/kubernikus-metal/Chart.yaml
+++ b/system/kubernikus-metal/Chart.yaml
@@ -18,7 +18,7 @@ version: 2.0.47
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-#appVersion: 1.16.0
+# appVersion: 1.16.0
 dependencies:
   - name: kubernikus
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/kubernikus-metal/values.yaml
+++ b/system/kubernikus-metal/values.yaml
@@ -1,5 +1,5 @@
 kubernikus:
-  imageTag: 30cacd446fdb3abe27118c5c85e9510a18999bd3
+  imageTag: 612781f18f839c8437b9b52b50adde2980493242
   image: keppel.global.cloud.sap/ccloud/kubernikus
 
   #use a dedicated serviceaccount and proper RBAC rules for this deployment

--- a/system/kubernikus-metal/values.yaml
+++ b/system/kubernikus-metal/values.yaml
@@ -2,7 +2,7 @@ kubernikus:
   imageTag: 612781f18f839c8437b9b52b50adde2980493242
   image: keppel.global.cloud.sap/ccloud/kubernikus
 
-  #use a dedicated serviceaccount and proper RBAC rules for this deployment
+  # use a dedicated serviceaccount and proper RBAC rules for this deployment
   standalone: false
   useServiceAccount: true
   includeRBAC: true


### PR DESCRIPTION
## Summary

- Bump `kubernikus-operator` image from `30cacd446fdb` (2026-04-02) to `612781f18f83` (2026-06-23) in `kubernikus-admin-k3s` and `kubernikus-metal` charts
- Fixes etcd pods getting stuck in `Init:0/1` due to `safe_guard` namespace mismatch after node replacements
- Fix introduced in https://github.com/sapcc/kubernikus/pull/1083

## Affected installations

| Chart | Covers |
|---|---|
| `system/kubernikus-admin-k3s` | `a-*` admin virtual installations |
| `system/kubernikus-metal` | `v-*` virtual installations (also hosts Metal and `st1-*` Storage clusters) |

`k-*` installations and `s-*` Scaleout clusters are not affected (already on fixed version).

## Test plan

- [ ] Verify operator rollout on one `a-*` cluster (e.g. `a-qa-de-1`)
- [ ] Verify operator rollout on one `v-*` cluster (e.g. `v-qa-de-1`)
- [ ] Confirm etcd pods come up cleanly after next node replacement