### PR TITLE
update hermes rate limit config

### DIFF
--- a/openstack/hermes/templates/etc/_hermes.conf.tpl
+++ b/openstack/hermes/templates/etc/_hermes.conf.tpl
@@ -15,3 +15,11 @@ password = "{{.Values.hermes.password | default "default"}}"
 user_domain_name = "Default"
 project_domain_name = "Default"
 project_name = "service"
+
+[API.RateLimit]
+RequestsPerSecond = {{.Values.hermes.rateLimit.requestsPerSecond | default 0}}
+Burst = {{.Values.hermes.rateLimit.burst | default 0}}
+DownloadRequestsPerSecond = {{.Values.hermes.rateLimit.downloadRequestsPerSecond | default 0}}
+DownloadBurst = {{.Values.hermes.rateLimit.downloadBurst | default 0}}
+EvictionInterval = "{{.Values.hermes.rateLimit.evictionInterval | default "5m"}}"
+MaxIdlePeriod = "{{.Values.hermes.rateLimit.maxIdlePeriod | default "10m"}}"

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -40,6 +40,18 @@ hermes:
     # hostnames are derived from this template using the key of the targets entry
     host_template: "%s-rabbitmq-notifications.monsoon3"
 
+  # Per-token rate limiting for the Hermes API.
+  # 0 (default) disables rate limiting. Enable per region as needed.
+  # Typical values: requestsPerSecond=2, burst=10 for the default endpoints;
+  # downloadRequestsPerSecond=0.2, downloadBurst=3 for the heavier /download endpoint.
+  rateLimit:
+    requestsPerSecond: 0
+    burst: 0
+    downloadRequestsPerSecond: 0
+    downloadBurst: 0
+    evictionInterval: "5m"
+    maxIdlePeriod: "10m"
+
   # Audit-event publisher for hermes-api PUT/DELETE dataplane-config operations.
   # Reuses the rabbitmq_notifications subchart; events land on the
   # notifications.info queue alongside other OpenStack control-plane audit events.


### PR DESCRIPTION
## Motivation
The Hermes API binary now supports per-token rate limiting. The helm chart needs to
expose the new config keys so regions can opt in without editing templates directly.

## What Changed
- Added `hermes.rateLimit` block to `values.yaml` with all six parameters (all
  default to 0 / disabled for backward compatibility).
- Added the six `RateLimit.*` keys to `_hermes.conf.tpl` so they are rendered into
  the API config map.

Leave all at 0 to keep rate limiting disabled (the default).

Related PRs

- hermez PR: implements the rate limiting middleware
- secrets PR: enables rate limiting in qa-de-1
