### PR TITLE
Alert when Cinder pool aggregate ID is missing

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -166,3 +166,17 @@ groups:
     annotations:
       description: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} Netapp FQDN is not set"
       summary: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} Netapp FQDN is not set"
+  - alert: CinderPoolAggregateIDMissing
+    expr: >
+        cinder_pool_aggregate_id_missing == 1
+    for: 15m
+    labels:
+      severity: warning
+      tier: vmware
+      service: cinder
+      support_group: compute
+      context: "openstack-exporter"
+      meta: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} has no aggregate ID set"
+    annotations:
+      description: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} has no aggregate ID set"
+      summary: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} has no aggregate ID set"


### PR DESCRIPTION
## Summary
- Add a Cinder alert for pools without an aggregate ID.
- Include shard, backend, and pool in the alert metadata and annotations.

## Dependency
- Depends on https://github.com/sapcc/openstack-exporter/pull/34, which adds the cinder_pool_aggregate_id_missing metric.

## Verification
- helm lint . -f ci/test-values.yaml
- helm template openstack-exporter . -f ci/test-values.yaml --set openstack.alerts.enabled=true
- git diff --check
