### PR TITLE
system/kube-proxy: remove obsolete conntrack-nanny sidecar

### DIFF
--- a/system/kube-proxy/Chart.yaml
+++ b/system/kube-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube Proxy
 name: kube-proxy
-version: 0.6.41
+version: 0.6.42
 
 dependencies:
   - name: helm3-helper

--- a/system/kube-proxy/templates/daemonset.yaml
+++ b/system/kube-proxy/templates/daemonset.yaml
@@ -137,22 +137,6 @@ spec:
         securityContext:
             privileged: true
 {{- end }}
-{{- if .Values.sidecars.nanny }}
-      - name: nanny
-        imagePullPolicy: IfNotPresent
-        image: "{{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.images.nanny.image }}:{{ .Values.images.nanny.tag }}"
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 64Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-{{- end }}
 {{- if .Values.sidecars.ipmasq }}
       - name: ipmasq
         image: "{{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.images.ipmasq.image }}:{{ .Values.images.ipmasq.tag }}"

--- a/system/kube-proxy/values.yaml
+++ b/system/kube-proxy/values.yaml
@@ -19,9 +19,6 @@ images:
   externalip:
     repository: sapcc/kube-externalip
     tag: 0.3.2
-  nanny:
-    repository: sapcc/k8s-conntrack-nanny
-    tag: v0.1.0
   ipmasq:
     repository: sapcc/ip-masq-agent-amd64
     tag: v2.0.0 
@@ -29,7 +26,6 @@ images:
 sidecars:
   parrot:     true
   externalip: true
-  nanny:      true
   ipmasq:     true
 
 clusterCIDR: 100.64.0.0/10


### PR DESCRIPTION
- k8s-conntrack-nanny is a workaround for k8s <1.14; all clusters running this chart are well past it
- bump chart 0.6.41 -> 0.6.42