### PR TITLE
fix(elektra): migrate pgmetrics to v2.0+ databases format

### DIFF
--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -97,7 +97,8 @@ pgbackup:
 
 pgmetrics:
   isPostgresNG: true
-  db_name: monsoon-dashboard_production
+  databases:
+    monsoon-dashboard_production: {}
   alerts:
     support_group: containers
     service: elektra


### PR DESCRIPTION
## Summary
Update elektra's pgmetrics configuration to use the correct format for pgmetrics v2.0+, enabling database metrics exposure to Prometheus.

## Problem
The elektra deployment was not exposing PostgreSQL database metrics because it used the deprecated `db_name` configuration field. The pgmetrics chart v2.0.0 introduced a breaking change that requires `.Values.databases` instead of `.Values.db_name`. Without this configuration, no pgmetrics pod is created and no metrics are exposed.

## Changes
- Replace deprecated `db_name: monsoon-dashboard_production` with `databases: { monsoon-dashboard_production: {} }`