### PR TITLE
chore(pgmetrics): add database name sanitization for RFC 1123 compliance

### DIFF
--- a/common/pgmetrics/Chart.yaml
+++ b/common/pgmetrics/Chart.yaml
@@ -16,4 +16,8 @@ description: A Helm chart for Postgres Metrics
 #
 # 2.1.0
 # - Added support for inline templating in `.Values.alerts.prometheus`.
-version: 2.1.8 # this version number is SemVer as it gets used to auto bump
+#
+# 2.1.9
+# - Added sanitization of database names to ensure RFC 1123 compliance for Kubernetes resource names.
+#   Database names with underscores (e.g., `monsoon-dashboard_production`) are now supported.
+version: 2.1.9 # this version number is SemVer as it gets used to auto bump

--- a/common/pgmetrics/Chart.yaml
+++ b/common/pgmetrics/Chart.yaml
@@ -16,8 +16,4 @@ description: A Helm chart for Postgres Metrics
 #
 # 2.1.0
 # - Added support for inline templating in `.Values.alerts.prometheus`.
-#
-# 2.1.9
-# - Added sanitization of database names to ensure RFC 1123 compliance for Kubernetes resource names.
-#   Database names with underscores (e.g., `monsoon-dashboard_production`) are now supported.
 version: 2.1.9 # this version number is SemVer as it gets used to auto bump

--- a/common/pgmetrics/templates/_helpers.tpl
+++ b/common/pgmetrics/templates/_helpers.tpl
@@ -12,5 +12,5 @@ Converts to lowercase and replaces any non-compliant characters with hyphens.
 Usage: {{ include "pgmetrics.sanitizeName" "database_name" }}
 */}}
 {{- define "pgmetrics.sanitizeName" -}}
-{{- . | lower | regexReplaceAll "[^a-z0-9-]+" "-" -}}
+{{- regexReplaceAll "[^a-z0-9-]+" (lower .) "-" -}}
 {{- end -}}

--- a/common/pgmetrics/templates/_helpers.tpl
+++ b/common/pgmetrics/templates/_helpers.tpl
@@ -5,3 +5,12 @@
 {{- if eq (len .Values.databases) 0 }}
   {{- fail "pgmetrics: needs at least one entry in .Values.databases" }}
 {{- end }}
+
+{{/*
+Sanitize database name to be RFC 1123 compliant for Kubernetes resource names.
+Converts to lowercase and replaces any non-compliant characters with hyphens.
+Usage: {{ include "pgmetrics.sanitizeName" "database_name" }}
+*/}}
+{{- define "pgmetrics.sanitizeName" -}}
+{{- . | lower | regexReplaceAll "[^a-z0-9-]+" "-" -}}
+{{- end -}}

--- a/common/pgmetrics/templates/alerts.yaml
+++ b/common/pgmetrics/templates/alerts.yaml
@@ -2,7 +2,7 @@
 {{- $service := $.Values.alerts.service | default $.Release.Name }}
 
 {{- range $dbName := keys .Values.databases | sortAlpha }}
-{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName }}
+{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName | trim }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/common/pgmetrics/templates/alerts.yaml
+++ b/common/pgmetrics/templates/alerts.yaml
@@ -2,16 +2,17 @@
 {{- $service := $.Values.alerts.service | default $.Release.Name }}
 
 {{- range $dbName := keys .Values.databases | sortAlpha }}
+{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ $.Release.Name }}-pgmetrics-{{ $dbName }}-alerts
+  name: {{ $.Release.Name }}-pgmetrics-{{ $sanitizedDbName }}-alerts
   labels:
     prometheus: {{ tpl $.Values.alerts.prometheus $ | quote }}
 spec:
   groups:
-  - name: pg-database-{{ $dbName }}.alerts
+  - name: pg-database-{{ $sanitizedDbName }}.alerts
     rules:
     - alert: {{ title $service }}StuckTransactions
       expr: max(pg_stat_activity_max_tx_duration{datname="{{ $dbName }}"}) > 600
@@ -32,7 +33,7 @@ spec:
           `SELECT * FROM pg_stat_activity WHERE state = 'idle in transaction' AND backend_start < NOW() - interval '1 minute'`.
 
     - alert: {{ title $service }}PostgresMetricsEvalErrors
-      expr: max(pg_exporter_last_scrape_error{kubernetes_namespace="{{ $.Release.Namespace }}",name="{{ $.Release.Name }}-pgmetrics-{{ $dbName }}"}) > 0
+      expr: max(pg_exporter_last_scrape_error{kubernetes_namespace="{{ $.Release.Namespace }}",name="{{ $.Release.Name }}-pgmetrics-{{ $sanitizedDbName }}"}) > 0
       for: 5m
       labels:
         context: database
@@ -44,11 +45,11 @@ spec:
       annotations:
         summary: Evaluation error in Postgres DB metrics
         description: >
-          Some of the custom metrics in the postgres-exporter configuration cannot be evaluated. Check the {{ $.Release.Name }}-pgmetrics-{{ $dbName }} pod log for errors.
+          Some of the custom metrics in the postgres-exporter configuration cannot be evaluated. Check the {{ $.Release.Name }}-pgmetrics-{{ $sanitizedDbName }} pod log for errors.
 
     - alert: {{ title $service }}PostgresMetricsSlowCollection
       # slow-moving to avoid flapping during maintenance events etc.
-      expr: max(avg_over_time(scrape_duration_seconds{kubernetes_namespace="{{ $.Release.Namespace }}",name="{{ $.Release.Name }}-pgmetrics-{{ $dbName }}"}[30m])) > {{ $.Values.alerts.scrape_duration_threshold }}
+      expr: max(avg_over_time(scrape_duration_seconds{kubernetes_namespace="{{ $.Release.Namespace }}",name="{{ $.Release.Name }}-pgmetrics-{{ $sanitizedDbName }}"}[30m])) > {{ $.Values.alerts.scrape_duration_threshold }}
       for: 5m
       labels:
         context: database
@@ -60,6 +61,6 @@ spec:
       annotations:
         summary: Slow metrics collection in postgres-exporter
         description: >
-          The {{ $.Release.Name }}-pgmetrics-{{ $dbName }} pod is taking a long time to gather metrics. Check for throttling in the pgmetrics pod. If that's not a problem, this alert can be an early indication that the PostgreSQL server performance is degrading.
+          The {{ $.Release.Name }}-pgmetrics-{{ $sanitizedDbName }} pod is taking a long time to gather metrics. Check for throttling in the pgmetrics pod. If that's not a problem, this alert can be an early indication that the PostgreSQL server performance is degrading.
 {{- end }}
 {{- end }}

--- a/common/pgmetrics/templates/alerts.yaml
+++ b/common/pgmetrics/templates/alerts.yaml
@@ -2,7 +2,7 @@
 {{- $service := $.Values.alerts.service | default $.Release.Name }}
 
 {{- range $dbName := keys .Values.databases | sortAlpha }}
-{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName | trim }}
+{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/common/pgmetrics/templates/configmap-etc.yaml
+++ b/common/pgmetrics/templates/configmap-etc.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
 {{- range $dbName := keys .Values.databases | sortAlpha }}
 {{- $dbSettings := index $.Values.databases $dbName }}
-{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName | trim }}
+{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName }}
   custom-metrics-{{ $sanitizedDbName }}.yaml: |
     {{- $.Values.customMetrics | toYaml | replace "%PGDATABASE" $dbName | nindent 4 }}
     {{- if $dbSettings.customMetrics }}

--- a/common/pgmetrics/templates/configmap-etc.yaml
+++ b/common/pgmetrics/templates/configmap-etc.yaml
@@ -5,7 +5,8 @@ metadata:
 data:
 {{- range $dbName := keys .Values.databases | sortAlpha }}
 {{- $dbSettings := index $.Values.databases $dbName }}
-  custom-metrics-{{ $dbName }}.yaml: |
+{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName }}
+  custom-metrics-{{ $sanitizedDbName }}.yaml: |
     {{- $.Values.customMetrics | toYaml | replace "%PGDATABASE" $dbName | nindent 4 }}
     {{- if $dbSettings.customMetrics }}
       {{- $dbSettings.customMetrics | toYaml | nindent 4 }}

--- a/common/pgmetrics/templates/configmap-etc.yaml
+++ b/common/pgmetrics/templates/configmap-etc.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
 {{- range $dbName := keys .Values.databases | sortAlpha }}
 {{- $dbSettings := index $.Values.databases $dbName }}
-{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName }}
+{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName | trim }}
   custom-metrics-{{ $sanitizedDbName }}.yaml: |
     {{- $.Values.customMetrics | toYaml | replace "%PGDATABASE" $dbName | nindent 4 }}
     {{- if $dbSettings.customMetrics }}

--- a/common/pgmetrics/templates/deployment.yaml
+++ b/common/pgmetrics/templates/deployment.yaml
@@ -4,7 +4,7 @@
 
 {{- range $dbName := keys .Values.databases | sortAlpha }}
 {{- $dbSettings := index $.Values.databases $dbName }}
-{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName | trim }}
+{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName }}
 ---
 kind: Deployment
 apiVersion: apps/v1

--- a/common/pgmetrics/templates/deployment.yaml
+++ b/common/pgmetrics/templates/deployment.yaml
@@ -4,11 +4,12 @@
 
 {{- range $dbName := keys .Values.databases | sortAlpha }}
 {{- $dbSettings := index $.Values.databases $dbName }}
+{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName }}
 ---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: {{ $.Release.Name }}-pgmetrics-{{ $dbName }}
+  name: {{ $.Release.Name }}-pgmetrics-{{ $sanitizedDbName }}
   {{- if $.Values.reloader.enabled }}
   annotations:
     reloader.stakater.com/search: "true"
@@ -20,13 +21,13 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      name: {{ $.Release.Name }}-pgmetrics-{{ $dbName }}
+      name: {{ $.Release.Name }}-pgmetrics-{{ $sanitizedDbName }}
   template:
     metadata:
       labels:
-        name: {{ $.Release.Name }}-pgmetrics-{{ $dbName }}
+        name: {{ $.Release.Name }}-pgmetrics-{{ $sanitizedDbName }}
         app: {{ $.Release.Name }}-pgmetrics
-        component: {{ $dbName }}
+        component: {{ $sanitizedDbName }}
         type: metrics
       annotations:
         kubectl.kubernetes.io/default-container: metrics
@@ -55,7 +56,7 @@ spec:
           - name: metrics
             containerPort: 9187
         args:
-          - "--extend.query-path=/conf/custom-metrics-{{ $dbName }}.yaml"
+          - "--extend.query-path=/conf/custom-metrics-{{ $sanitizedDbName }}.yaml"
           - "--log.level=info"
           {{- range $collector, $enabled := $.Values.collectors }}
           - "--{{ if not $enabled }}no-{{- end }}collector.{{ $collector }}"

--- a/common/pgmetrics/templates/deployment.yaml
+++ b/common/pgmetrics/templates/deployment.yaml
@@ -4,7 +4,7 @@
 
 {{- range $dbName := keys .Values.databases | sortAlpha }}
 {{- $dbSettings := index $.Values.databases $dbName }}
-{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName }}
+{{- $sanitizedDbName := include "pgmetrics.sanitizeName" $dbName | trim }}
 ---
 kind: Deployment
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
Add sanitization of database names to ensure Kubernetes resource names comply with RFC 1123 DNS subdomain naming requirements, enabling support for database names with underscores.

## Problem
When using database names with underscores (e.g., `monsoon-dashboard_production`), the pgmetrics chart fails to deploy because Kubernetes resource names must follow RFC 1123 subdomain rules:
- Only lowercase alphanumeric characters, hyphens, and dots allowed
- Must start and end with an alphanumeric character

Error message:
Deployment.apps "elektra-pgmetrics-monsoon-dashboard_production" is invalid:
metadata.name: Invalid value: a lowercase RFC 1123 subdomain must consist of
lower case alphanumeric characters, '-' or '.', and must start and end with
an alphanumeric character

## Changes
1. **Added helper function** `pgmetrics.sanitizeName` in `_helpers.tpl`:
   - Converts database names to RFC 1123 compliant format
   - Reusable across all templates
   - Documented with usage examples

2. **Updated templates** to use sanitized names for Kubernetes resources:
   - `deployment.yaml`: Deployment name, labels, selectors, ConfigMap file references
   - `alerts.yaml`: PrometheusRule name, alert group names, pod label selectors
   - `configmap-etc.yaml`: ConfigMap data keys

3. **Preserved original database name** for:
   - PostgreSQL connection strings (DATA_SOURCE_URI)
   - Prometheus query expressions (datname label)
   - SQL queries and database operations

4. **Bumped version** to 2.1.9 with changelog entry