### PR TITLE
feat(greenhouse-org): add gatekeeper plugin

### DIFF
--- a/system/greenhouse-organization/templates/plugins/gatekeeper.yaml
+++ b/system/greenhouse-organization/templates/plugins/gatekeeper.yaml
@@ -1,0 +1,38 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.gatekeeper.enabled }}
+apiVersion: greenhouse.sap/v1alpha1
+kind: Plugin
+metadata:
+  name: gatekeeper
+  namespace: {{ .Release.Namespace }}
+  labels:
+    "greenhouse.sap/owned-by": {{ .Values.gatekeeper.supportGroup | default .Values.global.supportGroup }}
+spec:
+  displayName: OPA Gatekeeper
+  pluginDefinitionRef:
+    kind: PluginDefinition
+    name: gatekeeper
+  releaseName: gatekeeper
+  releaseNamespace: greenhouse
+  optionValues:
+    {{- if .Values.gatekeeper.replicas }}
+    - name: gatekeeper.replicas
+      value: {{ .Values.gatekeeper.replicas }}
+    {{- end }}
+    {{- if .Values.gatekeeper.auditInterval }}
+    - name: gatekeeper.auditInterval
+      value: {{ .Values.gatekeeper.auditInterval }}
+    {{- end }}
+    {{- if .Values.gatekeeper.validatingWebhookFailurePolicy }}
+    - name: gatekeeper.validatingWebhookFailurePolicy
+      value: {{ .Values.gatekeeper.validatingWebhookFailurePolicy | quote }}
+    {{- end }}
+    {{- if .Values.gatekeeper.logDenies }}
+    - name: gatekeeper.logDenies
+      value: {{ .Values.gatekeeper.logDenies }}
+    {{- end }}
+{{- end }}

--- a/system/greenhouse-organization/values.yaml
+++ b/system/greenhouse-organization/values.yaml
@@ -83,6 +83,7 @@ catalogs:
           - reloader/plugindefinition.yaml
           - shoot-grafter/plugindefinition.yaml
           - permission-manager/plugindefinition.yaml
+          - gatekeeper/plugindefinition.yaml
         overrides:
           - name: exposed-services
             repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
@@ -106,6 +107,8 @@ catalogs:
             repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
           - name: permission-manager
             repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/permission-manager/charts
+          - name: gatekeeper
+            repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
       - repository: https://github.wdf.sap.corp/sap-cloud-infrastructure/greenhouse-extensions
         ref:
           branch: main # using main for QA and playground, can be changed to a specific tag or commit for production
@@ -265,4 +268,7 @@ repoguard:
   enabled: false
 
 permissionmanager:
+  enabled: false
+
+gatekeeper:
   enabled: false


### PR DESCRIPTION
Add an OPA Gatekeeper plugin to the chart (off by default). It includes operator only (no `ConstraintTemplates` or `Constraints` yet)
