### PR TITLE
gatekeeper: bump memlimit of auditor

### DIFF
--- a/system/gatekeeper/values.yaml
+++ b/system/gatekeeper/values.yaml
@@ -105,7 +105,7 @@ gatekeeper-upstream:
     resources:
       limits:
         cpu: 2
-        memory: 1024Mi
+        memory: 1.5Gi
       requests:
         cpu: 500m
         memory: 256Mi


### PR DESCRIPTION
Some scaleout clusters e.g. in QA have so many violations that we're getting oomkilled.