### PR TITLE
fix(pmtud): fix CLI arguments when relayBackend is l2 or not set

### DIFF
--- a/system/go-pmtud/Chart.yaml
+++ b/system/go-pmtud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: go-pmtud
 description: go-pmtud
-version: 3.2.0
+version: 3.2.1
 home: https://github.com/sapcc/go-pmtud
 sources:
   - https://github.com/sapcc/go-pmtud

--- a/system/go-pmtud/templates/go-pmtud-daemonset.yaml
+++ b/system/go-pmtud/templates/go-pmtud-daemonset.yaml
@@ -53,8 +53,7 @@ spec:
           - --relay-backend=udp
           - --replication-port={{ .Values.pmtud.replicationPort | default 4390 }}
           {{- else }}
-          - --relay-backend=l2
-          - --iface_names={{ required ".Values.pmtud.ifaceNames is required for l2 backend" .Values.pmtud.ifaceNames | join "," }}
+          - --iface_names={{ required ".Values.pmtud.ifaceNames is required" .Values.pmtud.ifaceNames | join "," }}
           {{- if .Values.pmtud.ifaceMtu }}
           - --iface_mtu={{ .Values.pmtud.ifaceMtu }}
           {{- end }}


### PR DESCRIPTION
#12736 broke the deployment when an image without the relay-backend is used. Pods crash with

```
Error: unknown flag: --relay-backend
Usage:
  pmtud [flags]

Flags:
      --arp-timeout-seconds int    Timeout in seconds for node arp request (default 1)
      --health_port string         Port for healthz (default ":30041")
  -h, --help                       help for pmtud
      --iface_mtu int              MTU size that replication interface should have (default 1500)
      --iface_names strings        Replication interface names to work on
      --kube_context string        kube-context to use
      --kubeconfig string          Paths to a kubeconfig. Only required if out-of-cluster.
      --metrics_port string        Port for Prometheus metrics (default ":30040")
      --nflog_group uint16         NFLOG group (default 33)
      --node-timeout-minutes int   Timeout in minutes for node arp entry (default 5)
      --nodename string            Node hostname
      --ttl int                    TTL for resent packets (default 1)

unknown flag: --relay-backend
```

This PR removes the `--relay-backend` CLI argument if value `relayBackend != udp`