### PR TITLE
[cc3test] api test cronjob expression fix

### DIFF
--- a/openstack/cc3test/Chart.yaml
+++ b/openstack/cc3test/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: cc3test - for blackbox testing the CC+1
 name: cc3test
-version: 0.2.2
+version: 0.2.3
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cc3test/templates/cronjob-api.yaml
+++ b/openstack/cc3test/templates/cronjob-api.yaml
@@ -33,7 +33,7 @@ spec:
           - name: cc3test-api
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/linkerd-await"]
-            args: ["--shutdown", "--", "/bin/sh", "-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -m api tests; exit 0"]
+            args: ["--shutdown", "--", "/bin/sh", "-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -m api --ignore=tests/compute_kvm --ignore=tests/logical_network_separation --ignore=tests/validation --ignore=tests/compute/test_server.py --ignore=tests/compute/test_compute_host.py tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config


### PR DESCRIPTION
* ApI tests are not running since 03-09-2026 in eu-de-1
* Issue with API test pod
* API Tests were running for every 5 mins interval, but in eu-de-1 the test run is taking more than 5 mins so the test pod is getting terminated and new pod is getting started and these pods are getting terminated without completion of the test run so there is no api test metrics found in eu-de-1