### PR TITLE
argora-operator{,-remote}: bump argora chart to d409d47 (#176)

### DIFF
--- a/system/argora-operator-remote/Chart.lock
+++ b/system/argora-operator-remote/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: argora
   repository: oci://ghcr.io/sapcc/charts
-  version: 0.0.1-20260904122056-d2a5ac1-crds
-digest: sha256:6421c0c6d18c7c3034f1de53a64cf1762b4fd0f16bef0f2615d050967621c508
-generated: "2026-09-04T12:30:44.464022174Z"
+  version: 0.0.1-20260909122135-d409d47-crds
+digest: sha256:3e29624d0153a909fe04395597745dfdcbea9df2839e61f5f3c323b0ab7d7fe4
+generated: "2026-09-09T15:16:01.760761+02:00"

--- a/system/argora-operator-remote/Chart.yaml
+++ b/system/argora-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.65
+version: 0.0.66
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -25,5 +25,5 @@ dependencies:
     version: ">= 0.0.0"
   - name: argora
     repository: oci://ghcr.io/sapcc/charts
-    version: 0.0.1-20260904122056-d2a5ac1-crds
+    version: 0.0.1-20260909122135-d409d47-crds
     alias: argora-operator-core

--- a/system/argora-operator-remote/managedresources/crds-and-rbac.yaml
+++ b/system/argora-operator-remote/managedresources/crds-and-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260904122056-d2a5ac1-crds
+    helm.sh/chart: argora-0.0.1-20260909122135-d409d47-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-controller-manager
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260904122056-d2a5ac1-crds
+    helm.sh/chart: argora-0.0.1-20260909122135-d409d47-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: clusterimports.argora.cloud.sap
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260904122056-d2a5ac1-crds
+    helm.sh/chart: argora-0.0.1-20260909122135-d409d47-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: ippoolimports.argora.cloud.sap
@@ -219,6 +219,19 @@ spec:
                         type: string
                       namePrefix:
                         type: string
+                      prefix:
+                        description: |-
+                          Prefix optionally restricts the selection to the single NetBox prefix with
+                          this exact CIDR. Use it to disambiguate when region+role match more than one
+                          prefix (e.g. several management-transit networks share a region and role).
+                          An empty value means no prefix filter. MaxLength is capped at 17 to keep the
+                          isCIDR CEL rule within the apiserver's per-schema cost budget; that fits every
+                          NetBox prefix in scope (IPv4 network CIDRs such as 10.219.139.128/26).
+                        maxLength: 17
+                        type: string
+                        x-kubernetes-validations:
+                          - message: prefix must be a valid CIDR
+                            rule: self == '' || isCIDR(self)
                       region:
                         type: string
                       role:
@@ -313,7 +326,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260904122056-d2a5ac1-crds
+    helm.sh/chart: argora-0.0.1-20260909122135-d409d47-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: updates.argora.cloud.sap
@@ -449,7 +462,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260904122056-d2a5ac1-crds
+    helm.sh/chart: argora-0.0.1-20260909122135-d409d47-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-manager-role
@@ -619,7 +632,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260904122056-d2a5ac1-crds
+    helm.sh/chart: argora-0.0.1-20260909122135-d409d47-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-manager-rolebinding

--- a/system/argora-operator/Chart.lock
+++ b/system/argora-operator/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: argora
   repository: oci://ghcr.io/sapcc/charts
-  version: 0.0.1-20260904122056-d2a5ac1
-digest: sha256:917e32bf5caa8be2439bd026ac0b1b973f9513cca4cb967ecc63ab8d23b6045b
-generated: "2026-09-04T12:30:48.045151759Z"
+  version: 0.0.1-20260909122135-d409d47
+digest: sha256:9b4ae54c371516bd87b7f405d950fcc011cd64d87986b0fa78f91abd726d5098
+generated: "2026-09-09T15:15:49.598051+02:00"

--- a/system/argora-operator/Chart.yaml
+++ b/system/argora-operator/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: argora-operator
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.54
+version: 0.0.55
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ">= 0.0.0"
   - name: argora
     repository: oci://ghcr.io/sapcc/charts
-    version: 0.0.1-20260904122056-d2a5ac1
+    version: 0.0.1-20260909122135-d409d47
     alias: argora-operator-core


### PR DESCRIPTION
Bumps the \`argora-operator\` and \`argora-operator-remote\` charts to pick up [sapcc/argora#176](https://github.com/sapcc/argora/pull/176) — the optional **exact-prefix `IPPoolImport` selector**.

## What changed
Ran the standard make targets from `system/`:
- `make build-argora-operator` → dep `argora` `0.0.1-20260904122056-d2a5ac1` → `0.0.1-20260909122135-d409d47`, chart `0.0.54` → `0.0.55`
- `make build-argora-operator-remote` → dep `argora` `...-d2a5ac1-crds` → `0.0.1-20260909122135-d409d47-crds`, chart `0.0.65` → `0.0.66`, and re-rendered `managedresources/crds-and-rbac.yaml`

The re-rendered `IPPoolImport` CRD adds the new optional `prefix` field:
```yaml
prefix:
  maxLength: 17
  type: string
  x-kubernetes-validations:
    - message: prefix must be a valid CIDR
      rule: self == '' || isCIDR(self)
```
`d409d47` is argora#176 merged to `main`; the `0.0.1-20260909122135-d409d47[-crds]` charts were built from it by the argora pipeline.

## Why
Region + role alone can match several NetBox prefixes; the `prefix` selector lets an `IPPoolImport` target one exact CIDR. This unblocks scoping the **a-qa-de-200 management** `IPPoolImport` to the single QA-DE-200 transit prefix (`10.219.139.128/26`) instead of collapsing/colliding across the mgmt-qa-de-1 AZ networks.