### PR TITLE
feat(storage): rook-crds upgrade v1.18.11

### DIFF
--- a/system/rook-crds/Chart.yaml
+++ b/system/rook-crds/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: rook-crds
 description: A Helm chart containing Rook CRDs.
 type: application
-version: 0.0.1-rook.1.17.5
+version: 0.0.1-rook.1.18.11

--- a/system/rook-crds/crds/cephblockpoolradosnamespaces.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephblockpoolradosnamespaces.ceph.rook.io.yaml
@@ -8,7 +8,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephblockpoolradosnamespaces.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -65,6 +65,18 @@ spec:
                   type: string
                   x-kubernetes-validations:
                     - message: blockPoolName is immutable
+                      rule: self == oldSelf
+                clusterID:
+                  description: |-
+                    ClusterID to be used for this RadosNamespace in the CSI configuration.
+                    It must be unique among all Ceph clusters managed by Rook.
+                    If not specified, the clusterID will be generated and can be found in the CR status.
+                  maxLength: 36
+                  minLength: 1
+                  pattern: ^[a-zA-Z0-9_-]+$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: ClusterID is immutable
                       rule: self == oldSelf
                 mirroring:
                   description: Mirroring configuration of CephBlockPoolRadosNamespace

--- a/system/rook-crds/crds/cephblockpools.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephblockpools.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephblockpools.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -95,6 +95,7 @@ spec:
                   type: string
                 enableCrushUpdates:
                   description: Allow rook operator to change the pool CRUSH tunables once the pool is created
+                  nullable: true
                   type: boolean
                 enableRBDStats:
                   description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
@@ -103,7 +104,12 @@ spec:
                   description: The erasure code settings
                   properties:
                     algorithm:
-                      description: The algorithm for erasure coding
+                      description: |-
+                        The algorithm for erasure coding.
+                        If absent, defaults to the plugin specified in osd_pool_default_erasure_code_profile.
+                      enum:
+                        - isa
+                        - jerasure
                       type: string
                     codingChunks:
                       description: |-
@@ -259,6 +265,32 @@ spec:
             status:
               description: CephBlockPoolStatus represents the mirroring status of Ceph Storage Pool
               properties:
+                cephx:
+                  description: PeerTokenCephxStatus represents the cephx key rotation status for peer tokens
+                  properties:
+                    peerToken:
+                      description: PeerToken shows the rotation status of the peer token associated with the `rbd-mirror-peer` user.
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
                 conditions:
                   items:
                     description: Condition represents a status condition on any Rook-Ceph Custom Resource.

--- a/system/rook-crds/crds/cephbucketnotifications.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephbucketnotifications.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephbucketnotifications.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -16,7 +16,14 @@ spec:
     singular: cephbucketnotification
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           description: CephBucketNotification represents a Bucket Notifications
@@ -44,7 +51,9 @@ spec:
                 events:
                   description: List of events that should trigger the notification
                   items:
-                    description: BucketNotificationSpec represent the event type of the bucket notification
+                    description: |-
+                      BucketNotificationSpec represent the event type of the bucket notification
+                      See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
                     enum:
                       - s3:ObjectCreated:*
                       - s3:ObjectCreated:Put
@@ -54,6 +63,28 @@ spec:
                       - s3:ObjectRemoved:*
                       - s3:ObjectRemoved:Delete
                       - s3:ObjectRemoved:DeleteMarkerCreated
+                      - s3:ObjectLifecycle:Expiration:Current
+                      - s3:ObjectLifecycle:Expiration:NonCurrent
+                      - s3:ObjectLifecycle:Expiration:DeleteMarker
+                      - s3:ObjectLifecycle:Expiration:AbortMultipartUpload
+                      - s3:ObjectLifecycle:Transition:Current
+                      - s3:ObjectLifecycle:Transition:NonCurrent
+                      - s3:LifecycleExpiration:*
+                      - s3:LifecycleExpiration:Delete
+                      - s3:LifecycleExpiration:DeleteMarkerCreated
+                      - s3:LifecycleTransition
+                      - s3:ObjectSynced:*
+                      - s3:ObjectSynced:Create
+                      - s3:ObjectSynced:Delete
+                      - s3:ObjectSynced:DeletionMarkerCreated
+                      - s3:Replication:*
+                      - s3:Replication:Create
+                      - s3:Replication:Delete
+                      - s3:Replication:DeletionMarkerCreated
+                      - s3:ObjectRestore:*
+                      - s3:ObjectRestore:Post
+                      - s3:ObjectRestore:Completed
+                      - s3:ObjectRestore:Delete
                     type: string
                   type: array
                 filter:

--- a/system/rook-crds/crds/cephbuckettopics.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephbuckettopics.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephbuckettopics.ceph.rook.io
 spec:
   group: ceph.rook.io

--- a/system/rook-crds/crds/cephclients.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephclients.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephclients.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -55,12 +55,78 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 name:
                   type: string
+                removeSecret:
+                  description: |-
+                    RemoveSecret indicates whether the current secret for this ceph client should be removed or not.
+                    If true, the K8s secret will be deleted, but the cephx keyring will remain until the CR is deleted.
+                  type: boolean
+                secretName:
+                  description: |-
+                    SecretName is the name of the secret created for this ceph client.
+                    If not specified, the default name is "rook-ceph-client-" as a prefix to the CR name.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: SecretName is immutable and cannot be changed
+                      rule: self == oldSelf
+                security:
+                  description: Security represents security settings
+                  properties:
+                    cephx:
+                      description: 'CephX configures CephX key settings. More: https://docs.ceph.com/en/latest/dev/cephx/'
+                      properties:
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration specifies the desired CephX key generation. This is used when KeyRotationPolicy
+                            is KeyGeneration and ignored for other policies. If this is set to greater than the current
+                            key generation, relevant keys will be rotated, and the generation value will be updated to
+                            this new value (generation values are not necessarily incremental, though that is the
+                            intended use case). If this is set to less than or equal to the current key generation, keys
+                            are not rotated.
+                          format: int32
+                          maximum: 4294967295
+                          minimum: 0
+                          type: integer
+                          x-kubernetes-validations:
+                            - message: keyGeneration cannot be decreased
+                              rule: self >= oldSelf
+                        keyRotationPolicy:
+                          description: |-
+                            KeyRotationPolicy controls if and when CephX keys are rotated after initial creation.
+                            One of Disabled, or KeyGeneration. Default Disabled.
+                          enum:
+                            - ""
+                            - Disabled
+                            - KeyGeneration
+                          type: string
+                      type: object
+                  type: object
               required:
                 - caps
               type: object
             status:
               description: Status represents the status of a Ceph Client
               properties:
+                cephx:
+                  properties:
+                    keyCephVersion:
+                      description: |-
+                        KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                        same string format as reported by `CephCluster.status.version.version` to allow them to be
+                        compared. E.g., `20.2.0-0`.
+                        For all newly-created resources, this field set to the version of Ceph that created the key.
+                        The special value "Uninitialized" indicates that keys are being created for the first time.
+                        An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                      type: string
+                    keyGeneration:
+                      description: |-
+                        KeyGeneration represents the CephX key generation for the last successful reconcile.
+                        For all newly-created resources, this field is set to `1`.
+                        When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                        the configured policy generation.
+                        Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                      format: int32
+                      type: integer
+                  type: object
                 info:
                   additionalProperties:
                     type: string

--- a/system/rook-crds/crds/cephclusters.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephclusters.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephclusters.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -223,6 +223,11 @@ spec:
                           description: Enables read affinity for CSI driver.
                           type: boolean
                       type: object
+                    skipUserCreation:
+                      description: |-
+                        SkipUserCreation determines whether CSI users and their associated secrets should be skipped.
+                        If set to true, the user must manually manage these secrets.
+                      type: boolean
                   type: object
                 dashboard:
                   description: Dashboard settings
@@ -283,7 +288,7 @@ spec:
                     pgHealthyRegex:
                       description: |-
                         PgHealthyRegex is the regular expression that is used to determine which PG states should be considered healthy.
-                        The default is `^(active\+clean|active\+clean\+scrubbing|active\+clean\+scrubbing\+deep)$`
+                        The default is `^active(\+(clean|deep|scrubbing|snaptrim|snaptrim_wait))+$`
                       type: string
                   type: object
                 external:
@@ -680,6 +685,9 @@ spec:
                       maximum: 5
                       minimum: 0
                       type: integer
+                    hostNetwork:
+                      description: Whether host networking is enabled for the Ceph Mgr. If not set, the network settings from CephCluster.spec.networking will be applied.
+                      type: boolean
                     modules:
                       description: Modules is the list of ceph manager modules to enable/disable
                       items:
@@ -1453,6 +1461,10 @@ spec:
                     exporter:
                       description: Ceph exporter configuration
                       properties:
+                        hostNetwork:
+                          description: Whether host networking is enabled for CephExporter. If not set, the network settings from CephCluster.spec.networking will be applied.
+                          nullable: true
+                          type: boolean
                         perfCountersPrioLimit:
                           default: 5
                           description: Only performance counters greater than or equal to this option are fetched
@@ -1467,7 +1479,9 @@ spec:
                     externalMgrEndpoints:
                       description: ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
                       items:
-                        description: EndpointAddress is a tuple that describes single IP address.
+                        description: |-
+                          EndpointAddress is a tuple that describes single IP address.
+                          Deprecated: This API is deprecated in v1.33+.
                         properties:
                           hostname:
                             description: The Hostname of this endpoint
@@ -2290,8 +2304,116 @@ spec:
                   description: Security represents security settings
                   nullable: true
                   properties:
+                    cephx:
+                      description: 'CephX configures CephX key settings. More: https://docs.ceph.com/en/latest/dev/cephx/'
+                      properties:
+                        csi:
+                          description: |-
+                            CSI configures CephX key rotation settings for the Ceph-CSI daemons in the current Kubernetes cluster.
+                            CSI key rotation can affect existing PV connections, so take care when exercising this option.
+                          properties:
+                            keepPriorKeyCountMax:
+                              description: |-
+                                KeepPriorKeyCountMax tells Rook how many prior keys to keep active.
+                                Generally, this would be set to 1 to allow for a migration period for applications.
+                                If desired, set this to 0 to delete prior keys after migration.
+                                This config only applies to prior keys that already exist.
+                                If PriorKeyCount is set to 2 while only a single key currently exists, only a single prior key will be kept,
+                                and the reported status will only indicate the actual number of prior keys,
+                                not necessarily a reflection of PriorKeyCount config here.
+                              maximum: 10
+                              minimum: 0
+                              type: integer
+                            keyGeneration:
+                              description: |-
+                                KeyGeneration specifies the desired CephX key generation. This is used when KeyRotationPolicy
+                                is KeyGeneration and ignored for other policies. If this is set to greater than the current
+                                key generation, relevant keys will be rotated, and the generation value will be updated to
+                                this new value (generation values are not necessarily incremental, though that is the
+                                intended use case). If this is set to less than or equal to the current key generation, keys
+                                are not rotated.
+                              format: int32
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                              x-kubernetes-validations:
+                                - message: keyGeneration cannot be decreased
+                                  rule: self >= oldSelf
+                            keyRotationPolicy:
+                              description: |-
+                                KeyRotationPolicy controls if and when CephX keys are rotated after initial creation.
+                                One of Disabled, or KeyGeneration. Default Disabled.
+                              enum:
+                                - ""
+                                - Disabled
+                                - KeyGeneration
+                              type: string
+                          type: object
+                        daemon:
+                          description: |-
+                            Daemon configures CephX key settings for local Ceph daemons managed by Rook and part of the
+                            Ceph cluster. Daemon CephX keys can be rotated without affecting client connections.
+                          properties:
+                            keyGeneration:
+                              description: |-
+                                KeyGeneration specifies the desired CephX key generation. This is used when KeyRotationPolicy
+                                is KeyGeneration and ignored for other policies. If this is set to greater than the current
+                                key generation, relevant keys will be rotated, and the generation value will be updated to
+                                this new value (generation values are not necessarily incremental, though that is the
+                                intended use case). If this is set to less than or equal to the current key generation, keys
+                                are not rotated.
+                              format: int32
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                              x-kubernetes-validations:
+                                - message: keyGeneration cannot be decreased
+                                  rule: self >= oldSelf
+                            keyRotationPolicy:
+                              description: |-
+                                KeyRotationPolicy controls if and when CephX keys are rotated after initial creation.
+                                One of Disabled, or KeyGeneration. Default Disabled.
+                              enum:
+                                - ""
+                                - Disabled
+                                - KeyGeneration
+                              type: string
+                          type: object
+                        rbdMirrorPeer:
+                          description: |-
+                            RBDMirrorPeer configures CephX key settings of the `rbd-mirror-peer` user that is used for creating
+                            bootstrap peer token used connect peer clusters. Rotating the `rbd-mirror-peer` user key will update
+                            the mirror peer token.
+                            Rotation will affect any existing peers connected to this cluster, so take care when exercising this option.
+                          properties:
+                            keyGeneration:
+                              description: |-
+                                KeyGeneration specifies the desired CephX key generation. This is used when KeyRotationPolicy
+                                is KeyGeneration and ignored for other policies. If this is set to greater than the current
+                                key generation, relevant keys will be rotated, and the generation value will be updated to
+                                this new value (generation values are not necessarily incremental, though that is the
+                                intended use case). If this is set to less than or equal to the current key generation, keys
+                                are not rotated.
+                              format: int32
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                              x-kubernetes-validations:
+                                - message: keyGeneration cannot be decreased
+                                  rule: self >= oldSelf
+                            keyRotationPolicy:
+                              description: |-
+                                KeyRotationPolicy controls if and when CephX keys are rotated after initial creation.
+                                One of Disabled, or KeyGeneration. Default Disabled.
+                              enum:
+                                - ""
+                                - Disabled
+                                - KeyGeneration
+                              type: string
+                          type: object
+                      type: object
                     keyRotation:
-                      description: KeyRotation defines options for Key Rotation.
+                      description: KeyRotation defines options for rotation of OSD disk encryption keys.
                       nullable: true
                       properties:
                         enabled:
@@ -2732,6 +2854,11 @@ spec:
                       type: array
                     onlyApplyOSDPlacement:
                       type: boolean
+                    osdMaxUpdatesInParallel:
+                      description: The maximum number of OSDs to update in parallel.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     scheduleAlways:
                       description: Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready
                       type: boolean
@@ -4433,6 +4560,189 @@ spec:
                             type: integer
                           description: Rgw shows Rgw Ceph version
                           type: object
+                      type: object
+                  type: object
+                cephx:
+                  description: ClusterCephxStatus defines the cephx key rotation status of various daemons on the cephCluster resource
+                  properties:
+                    admin:
+                      description: Admin shows the CephX key status for the client.admin key
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                    cephExporter:
+                      description: Ceph Exporter represents the cephx key rotation status of the ceph exporter daemon
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                    crashCollector:
+                      description: Crash Collector represents the cephx key rotation status of the crash collector daemon
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                    csi:
+                      description: CSI shows the CephX key status for Ceph-CSI components.
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                        priorKeyCount:
+                          description: PriorKeyCount reports the number of prior-generation CephX keys that remain active for the related component
+                          type: integer
+                      type: object
+                    mgr:
+                      description: Mgr represents the cephx key rotation status of the ceph manager daemon
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                    mon:
+                      description: Mon represents the CephX key status of the Monitor daemons
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                    osd:
+                      description: OSD shows the CephX key status of of OSDs
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                    rbdMirrorPeer:
+                      description: RBDMirrorPeer represents the cephx key rotation status of the `rbd-mirror-peer` user
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
                       type: object
                   type: object
                 conditions:

--- a/system/rook-crds/crds/cephcosidrivers.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephcosidrivers.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephcosidrivers.ceph.rook.io
 spec:
   group: ceph.rook.io

--- a/system/rook-crds/crds/cephfilesystemmirrors.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephfilesystemmirrors.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephfilesystemmirrors.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -635,8 +635,33 @@ spec:
                   type: object
               type: object
             status:
-              description: Status represents the status of an object
+              description: FileMirrorStatus represents the status of the FileSystem mirror resource
               properties:
+                cephx:
+                  properties:
+                    daemon:
+                      description: Daemon shows the CephX key status for local Ceph daemons associated with this resources.
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
                 conditions:
                   items:
                     description: Condition represents a status condition on any Rook-Ceph Custom Resource.

--- a/system/rook-crds/crds/cephfilesystems.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephfilesystems.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephfilesystems.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -83,6 +83,7 @@ spec:
                         type: string
                       enableCrushUpdates:
                         description: Allow rook operator to change the pool CRUSH tunables once the pool is created
+                        nullable: true
                         type: boolean
                       enableRBDStats:
                         description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
@@ -91,7 +92,12 @@ spec:
                         description: The erasure code settings
                         properties:
                           algorithm:
-                            description: The algorithm for erasure coding
+                            description: |-
+                              The algorithm for erasure coding.
+                              If absent, defaults to the plugin specified in osd_pool_default_erasure_code_profile.
+                            enum:
+                              - isa
+                              - jerasure
                             type: string
                           codingChunks:
                             description: |-
@@ -272,6 +278,7 @@ spec:
                       type: string
                     enableCrushUpdates:
                       description: Allow rook operator to change the pool CRUSH tunables once the pool is created
+                      nullable: true
                       type: boolean
                     enableRBDStats:
                       description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
@@ -280,7 +287,12 @@ spec:
                       description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
+                          description: |-
+                            The algorithm for erasure coding.
+                            If absent, defaults to the plugin specified in osd_pool_default_erasure_code_profile.
+                          enum:
+                            - isa
+                            - jerasure
                           type: string
                         codingChunks:
                           description: |-
@@ -450,6 +462,22 @@ spec:
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    cacheMemoryLimitFactor:
+                      description: |-
+                        CacheMemoryLimitFactor is the factor applied to the memory limit to determine the MDS cache memory limit.
+                        MDS cache memory limit should be set to 50-60% of RAM reserved for the MDS container.
+                        MDS uses approximately 125% of the value of mds_cache_memory_limit in RAM.
+                        This factor is applied when resources.limits.memory is set.
+                      maximum: 1
+                      minimum: 0
+                      type: number
+                    cacheMemoryRequestFactor:
+                      description: |-
+                        CacheMemoryRequestFactor is the factor applied to the memory request to determine the MDS cache memory limit.
+                        This factor is applied when resources.requests.memory is set and resources.limits.memory is not set.
+                      maximum: 1
+                      minimum: 0
+                      type: number
                     labels:
                       additionalProperties:
                         type: string
@@ -1409,6 +1437,31 @@ spec:
             status:
               description: CephFilesystemStatus represents the status of a Ceph Filesystem
               properties:
+                cephx:
+                  properties:
+                    daemon:
+                      description: Daemon shows the CephX key status for local Ceph daemons associated with this resources.
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
                 conditions:
                   items:
                     description: Condition represents a status condition on any Rook-Ceph Custom Resource.

--- a/system/rook-crds/crds/cephfilesystemsubvolumegroups.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephfilesystemsubvolumegroups.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephfilesystemsubvolumegroups.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -60,6 +60,18 @@ spec:
             spec:
               description: Spec represents the specification of a Ceph Filesystem SubVolumeGroup
               properties:
+                clusterID:
+                  description: |-
+                    ClusterID to be used for this subvolume group in the CSI configuration.
+                    It must be unique among all Ceph clusters managed by Rook.
+                    If not specified, the clusterID will be generated and can be found in the CR status.
+                  maxLength: 36
+                  minLength: 1
+                  pattern: ^[a-zA-Z0-9_-]+$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: ClusterID is immutable
+                      rule: self == oldSelf
                 dataPoolName:
                   description: The data pool name for the Ceph Filesystem subvolume group layout, if the default CephFS pool is not desired.
                   type: string

--- a/system/rook-crds/crds/cephnfses.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephnfses.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephnfses.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -16,7 +16,14 @@ spec:
     singular: cephnfs
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           description: CephNFS represents a Ceph NFS
@@ -1201,6 +1208,28 @@ spec:
                       description: Whether host networking is enabled for the Ganesha server. If not set, the network settings from the cluster CR will be applied.
                       nullable: true
                       type: boolean
+                    image:
+                      description: |-
+                        Image is the container image used to launch the Ceph NFS (Ganesha) daemon(s).
+                        The image must include the NFS Ganesha binaries, such as are included with the official Ceph releases. E.g.: quay.io/ceph/ceph:<tag>
+                        If not specified, the Ceph image defined in the CephCluster is used.
+                        Overriding the CephCluster defined image is not normally necessary when using the official Ceph images.
+                        The image must contain the NFS Ganesha and dbus packages.
+                        If the SSSD sidecar is enabled, the image must also contain the sssd-client package.
+                      maxLength: 1572864
+                      minLength: 1
+                      type: string
+                    imagePullPolicy:
+                      description: |-
+                        ImagePullPolicy describes a policy for if/when to pull a container image
+                        One of Always, Never, IfNotPresent.
+                        This field only has effect if an image is specified.
+                      enum:
+                        - IfNotPresent
+                        - Always
+                        - Never
+                        - ""
+                      type: string
                     labels:
                       additionalProperties:
                         type: string
@@ -1940,8 +1969,33 @@ spec:
                 - server
               type: object
             status:
-              description: Status represents the status of an object
+              description: NFSStatus represents the status of Ceph NFS
               properties:
+                cephx:
+                  properties:
+                    daemon:
+                      description: Daemon shows the CephX key status for local Ceph daemons associated with this resources.
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
                 conditions:
                   items:
                     description: Condition represents a status condition on any Rook-Ceph Custom Resource.

--- a/system/rook-crds/crds/cephobjectrealms.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephobjectrealms.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephobjectrealms.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -16,7 +16,14 @@ spec:
     singular: cephobjectrealm
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           description: CephObjectRealm represents a Ceph Object Store Gateway Realm
@@ -42,6 +49,9 @@ spec:
               description: ObjectRealmSpec represent the spec of an ObjectRealm
               nullable: true
               properties:
+                defaultRealm:
+                  description: Set this realm as the default in Ceph. Only one realm should be default.
+                  type: boolean
                 pull:
                   description: PullSpec represents the pulling specification of a Ceph Object Storage Gateway Realm
                   properties:

--- a/system/rook-crds/crds/cephobjectstores.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephobjectstores.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephobjectstores.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -130,6 +130,7 @@ spec:
                       type: string
                     enableCrushUpdates:
                       description: Allow rook operator to change the pool CRUSH tunables once the pool is created
+                      nullable: true
                       type: boolean
                     enableRBDStats:
                       description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
@@ -138,7 +139,12 @@ spec:
                       description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
+                          description: |-
+                            The algorithm for erasure coding.
+                            If absent, defaults to the plugin specified in osd_pool_default_erasure_code_profile.
+                          enum:
+                            - isa
+                            - jerasure
                           type: string
                         codingChunks:
                           description: |-
@@ -284,6 +290,13 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                defaultRealm:
+                  description: |-
+                    Set this realm as the default in Ceph. Only one realm should be default.
+                    Do not set this true on more than one CephObjectStore.
+                    This may not be set when zone is also specified; in this case, the realm
+                    referenced by the zone's zonegroup should configure defaulting behavior.
+                  type: boolean
                 gateway:
                   description: The rgw pod info
                   nullable: true
@@ -1731,6 +1744,7 @@ spec:
                       type: string
                     enableCrushUpdates:
                       description: Allow rook operator to change the pool CRUSH tunables once the pool is created
+                      nullable: true
                       type: boolean
                     enableRBDStats:
                       description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
@@ -1739,7 +1753,12 @@ spec:
                       description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
+                          description: |-
+                            The algorithm for erasure coding.
+                            If absent, defaults to the plugin specified in osd_pool_default_erasure_code_profile.
+                          enum:
+                            - isa
+                            - jerasure
                           type: string
                         codingChunks:
                           description: |-
@@ -2089,9 +2108,37 @@ spec:
                     - name
                   type: object
               type: object
+              x-kubernetes-validations:
+                - message: defaultRealm must not be true when zone.name is set (multisite configuration)
+                  rule: '!(has(self.defaultRealm) && self.defaultRealm == true && has(self.zone) && size(self.zone.name) > 0)'
             status:
               description: ObjectStoreStatus represents the status of a Ceph Object Store resource
               properties:
+                cephx:
+                  properties:
+                    daemon:
+                      description: Daemon shows the CephX key status for local Ceph daemons associated with this resources.
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
                 conditions:
                   items:
                     description: Condition represents a status condition on any Rook-Ceph Custom Resource.

--- a/system/rook-crds/crds/cephobjectstoreusers.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephobjectstoreusers.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephobjectstoreusers.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -187,7 +187,7 @@ spec:
                   description: The namespace where the parent CephCluster and CephObjectStore are found
                   type: string
                 displayName:
-                  description: The display name for the ceph users
+                  description: The display name for the ceph user.
                   type: string
                 keys:
                   description: |-

--- a/system/rook-crds/crds/cephobjectzonegroups.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephobjectzonegroups.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephobjectzonegroups.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -49,7 +49,7 @@ spec:
               description: ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup
               properties:
                 realm:
-                  description: The display name for the ceph users
+                  description: The name of the realm the zone group is a member of.
                   type: string
               required:
                 - realm

--- a/system/rook-crds/crds/cephobjectzones.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephobjectzones.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephobjectzones.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -94,6 +94,7 @@ spec:
                       type: string
                     enableCrushUpdates:
                       description: Allow rook operator to change the pool CRUSH tunables once the pool is created
+                      nullable: true
                       type: boolean
                     enableRBDStats:
                       description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
@@ -102,7 +103,12 @@ spec:
                       description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
+                          description: |-
+                            The algorithm for erasure coding.
+                            If absent, defaults to the plugin specified in osd_pool_default_erasure_code_profile.
+                          enum:
+                            - isa
+                            - jerasure
                           type: string
                         codingChunks:
                           description: |-
@@ -278,6 +284,7 @@ spec:
                       type: string
                     enableCrushUpdates:
                       description: Allow rook operator to change the pool CRUSH tunables once the pool is created
+                      nullable: true
                       type: boolean
                     enableRBDStats:
                       description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
@@ -286,7 +293,12 @@ spec:
                       description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
+                          description: |-
+                            The algorithm for erasure coding.
+                            If absent, defaults to the plugin specified in osd_pool_default_erasure_code_profile.
+                          enum:
+                            - isa
+                            - jerasure
                           type: string
                         codingChunks:
                           description: |-
@@ -525,7 +537,7 @@ spec:
                       type: boolean
                   type: object
                 zoneGroup:
-                  description: The display name for the ceph users
+                  description: The name of the zone group the zone is a member of.
                   type: string
               required:
                 - zoneGroup

--- a/system/rook-crds/crds/cephrbdmirrors.ceph.rook.io.yaml
+++ b/system/rook-crds/crds/cephrbdmirrors.ceph.rook.io.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cephrbdmirrors.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -655,8 +655,33 @@ spec:
                 - count
               type: object
             status:
-              description: Status represents the status of an object
+              description: RBDMirrorStatus represents the status of the RBD mirror resource
               properties:
+                cephx:
+                  properties:
+                    daemon:
+                      description: Daemon shows the CephX key status for local Ceph daemons associated with this resources.
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
                 conditions:
                   items:
                     description: Condition represents a status condition on any Rook-Ceph Custom Resource.


### PR DESCRIPTION
```bash
./get-crds v1.18.11
Getting Rook Operator CRDs in version v1.18.11
Fetched CRD cephblockpoolradosnamespaces.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephblockpoolradosnamespaces.ceph.rook.io.yaml
Fetched CRD cephblockpools.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephblockpools.ceph.rook.io.yaml
Fetched CRD cephnfses.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephnfses.ceph.rook.io.yaml
Fetched CRD cephobjectrealms.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephobjectrealms.ceph.rook.io.yaml
Fetched CRD cephobjectstores.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephobjectstores.ceph.rook.io.yaml
Fetched CRD cephobjectstoreusers.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephobjectstoreusers.ceph.rook.io.yaml
Fetched CRD cephobjectzonegroups.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephobjectzonegroups.ceph.rook.io.yaml
Fetched CRD cephobjectzones.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephobjectzones.ceph.rook.io.yaml
Fetched CRD cephrbdmirrors.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephrbdmirrors.ceph.rook.io.yaml
Fetched CRD objectbucketclaims.objectbucket.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/objectbucketclaims.objectbucket.io.yaml
Fetched CRD objectbuckets.objectbucket.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/objectbuckets.objectbucket.io.yaml
Fetched CRD cephbucketnotifications.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephbucketnotifications.ceph.rook.io.yaml
Fetched CRD cephbuckettopics.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephbuckettopics.ceph.rook.io.yaml
Fetched CRD cephclients.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephclients.ceph.rook.io.yaml
Fetched CRD cephclusters.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephclusters.ceph.rook.io.yaml
Fetched CRD cephcosidrivers.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephcosidrivers.ceph.rook.io.yaml
Fetched CRD cephfilesystemmirrors.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephfilesystemmirrors.ceph.rook.io.yaml
Fetched CRD cephfilesystems.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephfilesystems.ceph.rook.io.yaml
Fetched CRD cephfilesystemsubvolumegroups.ceph.rook.io to /home/ganesh/git_repo/sapcc/helm-charts/system/rook-crds/crds/cephfilesystemsubvolumegroups.ceph.rook.io.yaml
```