### PR TITLE
[barbican] add batched db-cleanup nanny container

### DIFF
--- a/openstack/barbican/templates/barbican-nanny-deployment.yaml
+++ b/openstack/barbican/templates/barbican-nanny-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.barbican_nanny.enabled }}
-{{- if .Values.barbican_nanny.db_secret_move.enabled }}
+{{- if or .Values.barbican_nanny.db_secret_move.enabled .Values.barbican_nanny.db_cleanup.enabled }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -107,6 +107,67 @@ spec:
           mountPath: /tmp
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
         {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
+{{- end }}
+{{- if .Values.barbican_nanny.db_cleanup.enabled }}
+      - name: db-cleanup
+        image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        command:
+        - dumb-init
+{{- if not .Values.barbican_nanny.debug }}
+        - /bin/bash
+        - /scripts/db-cleanup.sh
+{{- else }}
+        - sleep
+        - inf
+{{- end }}
+        env:
+        - name: BARBICAN_DB_CLEANUP_ENABLED
+          value: {{ .Values.barbican_nanny.db_cleanup.enabled | quote }}
+        - name: BARBICAN_DB_CLEANUP_BATCH_SIZE
+          value: {{ .Values.barbican_nanny.db_cleanup.batch_size | quote }}
+        - name: BARBICAN_DB_CLEANUP_MIN_NUM_DAYS
+          value: {{ .Values.barbican_nanny.db_cleanup.min_num_days | quote }}
+        - name: BARBICAN_DB_CLEANUP_CLEAN_UNASSOCIATED_PROJECTS
+          value: {{ .Values.barbican_nanny.db_cleanup.clean_unassociated_projects | quote }}
+        - name: BARBICAN_DB_CLEANUP_SOFT_DELETE_EXPIRED_SECRETS
+          value: {{ .Values.barbican_nanny.db_cleanup.soft_delete_expired_secrets | quote }}
+        - name: BARBICAN_NANNY_INTERVAL
+          value: {{ .Values.barbican_nanny.interval | quote }}
+        {{- if .Values.sentry.enabled }}
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: barbican.DSN.python
+        {{- end }}
+        resources:
+          requests:
+            memory: "250Mi"
+            cpu: "25m"
+          limits:
+            memory: "250Mi"
+            cpu: "100m"
+        volumeMounts:
+        - name: barbican-scripts
+          mountPath: /scripts/db-cleanup.sh
+          subPath: db-cleanup.sh
+          readOnly: true
+        - name: barbican-etc
+          mountPath: /etc/barbican/logging.ini
+          subPath: logging.ini
+          readOnly: true
+        - name: barbican-etc-confd
+          mountPath: /etc/barbican/barbican.conf.d
+          readOnly: true
+        - name: nanny-tmp
+          mountPath: /tmp
+        {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
+{{- end }}
       {{- if not .Values.proxysql.native_sidecar }}
       {{- tuple . 1 | include "utils.proxysql.container" | indent 6 }}
       {{- end }}
@@ -124,6 +185,5 @@ spec:
         emptyDir: {}
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/barbican/templates/barbican-nanny-deployment.yaml
+++ b/openstack/barbican/templates/barbican-nanny-deployment.yaml
@@ -135,8 +135,8 @@ spec:
           value: {{ .Values.barbican_nanny.db_cleanup.clean_unassociated_projects | quote }}
         - name: BARBICAN_DB_CLEANUP_SOFT_DELETE_EXPIRED_SECRETS
           value: {{ .Values.barbican_nanny.db_cleanup.soft_delete_expired_secrets | quote }}
-        - name: BARBICAN_NANNY_INTERVAL
-          value: {{ .Values.barbican_nanny.interval | quote }}
+        - name: BARBICAN_DB_CLEANUP_INTERVAL
+          value: {{ .Values.barbican_nanny.db_cleanup.interval | quote }}
         {{- if .Values.sentry.enabled }}
         - name: SENTRY_DSN
           valueFrom:

--- a/openstack/barbican/templates/scripts-configmap.yaml
+++ b/openstack/barbican/templates/scripts-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.barbican_nanny.db_secret_move.enabled }}
+{{- if or .Values.barbican_nanny.db_secret_move.enabled .Values.barbican_nanny.db_cleanup.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,6 +9,12 @@ metadata:
     component: barbican
 
 data:
+{{- if .Values.barbican_nanny.db_secret_move.enabled }}
   move-secrets.sh: |
 {{ include (print .Template.BasePath "/scripts/_move-secrets.sh.tpl") . | indent 4 }}
+{{- end }}
+{{- if .Values.barbican_nanny.db_cleanup.enabled }}
+  db-cleanup.sh: |
+{{ include (print .Template.BasePath "/scripts/_db-cleanup.sh.tpl") . | indent 4 }}
+{{- end }}
 {{- end}}

--- a/openstack/barbican/templates/scripts/_db-cleanup.sh.tpl
+++ b/openstack/barbican/templates/scripts/_db-cleanup.sh.tpl
@@ -34,12 +34,12 @@ while true; do
     if [ "$BARBICAN_DB_CLEANUP_ENABLED" = "True" ] || [ "$BARBICAN_DB_CLEANUP_ENABLED" = "true" ]; then
         date
         /var/lib/openstack/bin/barbican-manage db clean \
-            --min-num-days "$BARBICAN_DB_CLEANUP_MIN_NUM_DAYS" \
+            --min-days "$BARBICAN_DB_CLEANUP_MIN_NUM_DAYS" \
             --batch-size "$BARBICAN_DB_CLEANUP_BATCH_SIZE" \
             --verbose \
             $EXTRA_FLAGS
     fi
-    echo -n "INFO: waiting $BARBICAN_NANNY_INTERVAL minutes before starting the next loop run - "
+    echo -n "INFO: waiting $BARBICAN_DB_CLEANUP_INTERVAL minutes before starting the next loop run - "
     date
-    sleep $(( 60 * $BARBICAN_NANNY_INTERVAL ))
+    sleep $(( 60 * $BARBICAN_DB_CLEANUP_INTERVAL ))
 done

--- a/openstack/barbican/templates/scripts/_db-cleanup.sh.tpl
+++ b/openstack/barbican/templates/scripts/_db-cleanup.sh.tpl
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright (c) 2026 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+set -e
+
+unset http_proxy https_proxy all_proxy no_proxy
+
+EXTRA_FLAGS=""
+if [ "$BARBICAN_DB_CLEANUP_CLEAN_UNASSOCIATED_PROJECTS" = "True" ] || [ "$BARBICAN_DB_CLEANUP_CLEAN_UNASSOCIATED_PROJECTS" = "true" ]; then
+    EXTRA_FLAGS="$EXTRA_FLAGS --clean-unassociated-projects"
+fi
+if [ "$BARBICAN_DB_CLEANUP_SOFT_DELETE_EXPIRED_SECRETS" = "True" ] || [ "$BARBICAN_DB_CLEANUP_SOFT_DELETE_EXPIRED_SECRETS" = "true" ]; then
+    EXTRA_FLAGS="$EXTRA_FLAGS --soft-delete-expired-secrets"
+fi
+
+echo "INFO: starting a loop to periodically run the barbican db cleanup"
+while true; do
+
+    if [ "$BARBICAN_DB_CLEANUP_ENABLED" = "True" ] || [ "$BARBICAN_DB_CLEANUP_ENABLED" = "true" ]; then
+        date
+        /var/lib/openstack/bin/barbican-manage db clean \
+            --min-num-days "$BARBICAN_DB_CLEANUP_MIN_NUM_DAYS" \
+            --batch-size "$BARBICAN_DB_CLEANUP_BATCH_SIZE" \
+            --verbose \
+            $EXTRA_FLAGS
+    fi
+    echo -n "INFO: waiting $BARBICAN_NANNY_INTERVAL minutes before starting the next loop run - "
+    date
+    sleep $(( 60 * $BARBICAN_NANNY_INTERVAL ))
+done

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -567,9 +567,9 @@ barbican_nanny:
   db_cleanup:
     enabled: false
     # Number of rows deleted per committed batch (see barbican-manage db clean --batch-size)
-    batch_size: 10000
+    batch_size: 1000
     # Minimum age of soft-deleted rows to hard-delete (days); -1 means all
-    min_num_days: 14
+    min_num_days: 30
     # Sleep time in minutes between cleanup runs
     interval: 60
     clean_unassociated_projects: false

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -564,6 +564,14 @@ barbican_nanny:
   interval: 1
   db_secret_move:
     enabled: false
+  db_cleanup:
+    enabled: false
+    # Number of rows deleted per committed batch (see barbican-manage db clean --batch-size)
+    batch_size: 10000
+    # Minimum age of soft-deleted rows to hard-delete (days); -1 means all
+    min_num_days: 14
+    clean_unassociated_projects: false
+    soft_delete_expired_secrets: false
 
 # SCIBPL-218: restrict kubectl exec / port-forward / attach on the
 # barbican-api pods via a ValidatingAdmissionPolicy (K8s >= 1.30).

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -570,6 +570,8 @@ barbican_nanny:
     batch_size: 10000
     # Minimum age of soft-deleted rows to hard-delete (days); -1 means all
     min_num_days: 14
+    # Sleep time in minutes between cleanup runs
+    interval: 60
     clean_unassociated_projects: false
     soft_delete_expired_secrets: false
 


### PR DESCRIPTION
## Summary

Adds a `db-cleanup` sidecar container to the barbican-nanny Deployment that periodically runs `barbican-manage db clean` with the `--batch-size` flag introduced in sapcc/barbican#52. Without batching, the one-shot DELETE exhausts the InnoDB buffer pool on large deployments.

- New script template `scripts/_db-cleanup.sh.tpl` — loops on `$BARBICAN_DB_CLEANUP_INTERVAL`, passes `--batch-size`, `--min-days`, and optional `--clean-unassociated-projects` / `--soft-delete-expired-secrets` flags controlled by env vars
- `scripts-configmap.yaml` — gate changed from `db_secret_move.enabled` to `or db_secret_move.enabled db_cleanup.enabled`; `db-cleanup.sh` added conditionally
- `barbican-nanny-deployment.yaml` — outer gate updated to `or`; `move-secrets` and `db-cleanup` containers each independently conditional; `volumes:` block moved outside both container conditionals (latent bug in original)
- `values.yaml` — new `barbican_nanny.db_cleanup` block (all defaults off / safe)

New values:
```yaml
barbican_nanny:
  db_cleanup:
    enabled: false
    batch_size: 10000        # rows per committed batch
    min_num_days: 14         # threshold age for hard-deletes
    interval: 60             # minutes between cleanup runs
    clean_unassociated_projects: false
    soft_delete_expired_secrets: false
```

## Test plan

- [ ] `helm template` with `db_cleanup.enabled: false` produces identical output to current master (no regressions)
- [ ] `helm template` with `db_cleanup.enabled: true, db_secret_move.enabled: false` renders a single-container nanny Deployment with `db-cleanup` container and correct env vars
- [ ] `helm template` with both enabled renders both containers in the same pod