### PR TITLE
[manila-nanny] Require worker affinity

### DIFF
--- a/openstack/manila-nanny/Chart.yaml
+++ b/openstack/manila-nanny/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Manila Nanny - sync descrepancies from NetApp filers to Manila DB
 name: manila-nanny
 type: application
-version: 0.3.1
+version: 0.3.2
 
 appVersion: "0.0.0"
 sources:

--- a/openstack/manila-nanny/templates/deployment.yaml
+++ b/openstack/manila-nanny/templates/deployment.yaml
@@ -37,8 +37,18 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
-      nodeSelector:
-        zone: farm
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: zone
+                    operator: In
+                    values:
+                      - farm
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/worker
+                    operator: Exists
       volumes:
         - name: manila-etc
           configMap:


### PR DESCRIPTION
The Manila nanny deployment previously used a hard `nodeSelector` for `zone: farm`, which excluded worker nodes that did not carry that label. This change uses required node affinity with two alternative terms: nodes labeled `zone=farm`, or nodes carrying `node-role.kubernetes.io/worker`.