### PR TITLE
feat(greenhouse-org): add external-dns and kgateway plugins / plugindefinitions

### DIFF
--- a/system/greenhouse-organization/Chart.yaml
+++ b/system/greenhouse-organization/Chart.yaml
@@ -3,7 +3,7 @@ name: greenhouse-organization
 description: A Helm chart for resources required for running the Greenhouse
   admin organization in Greenhouse.
 type: application
-version: 0.6.17
+version: 0.6.18
 dependencies:
   - name: secrets-injector
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/greenhouse-organization/ci/test-values.yaml
+++ b/system/greenhouse-organization/ci/test-values.yaml
@@ -93,6 +93,28 @@ logshipping:
     enabled: true
     prometheusName: "myPrometheus"
 
+externalDns:
+  enabled: true
+  openstack:
+    enabled: true
+    authURL: https://identity.test
+    username: testuser
+    password: testpassword
+    projectID: testproject
+    regionName: testregion
+  options:
+    image:
+      tag: v0.22.0
+    provider:
+      name: webhook
+      webhook:
+        image:
+          repository: ghcr.io/inovex/external-dns-openstack-webhook
+          tag: v2.4.0
+    domainFilters:
+      - test.example.com
+    policy: sync
+
 openTelemetry:
   enabled: true
   prometheus:

--- a/system/greenhouse-organization/templates/_helpers.tpl
+++ b/system/greenhouse-organization/templates/_helpers.tpl
@@ -2,3 +2,24 @@
 {{- define "idproxy.auth.hostname" -}}
 {{- printf "%s.%s" "auth" (required "global.dnsDomain missing" .Values.global.dnsDomain) }}
 {{- end }}
+
+{{/*
+Flatten a nested map into dotted-key optionValues entries.
+Usage: {{ include "flattenOptionValues" (dict "prefix" "externaldns" "values" .Values.externalDns.options) }}
+*/}}
+{{- define "flattenOptionValues" -}}
+{{- $prefix := .prefix -}}
+{{- range $k, $v := .values -}}
+{{- $key := printf "%s.%s" $prefix $k -}}
+{{- if kindIs "map" $v }}
+{{- include "flattenOptionValues" (dict "prefix" $key "values" $v) }}
+{{- else if kindIs "slice" $v }}
+- name: {{ $key }}
+  value:
+{{ toYaml $v | indent 4 }}
+{{- else }}
+- name: {{ $key }}
+  value: {{ $v | toYaml | trim }}
+{{ end -}}
+{{- end -}}
+{{- end }}

--- a/system/greenhouse-organization/templates/plugins/cert-manager.yaml
+++ b/system/greenhouse-organization/templates/plugins/cert-manager.yaml
@@ -11,8 +11,8 @@ spec:
     name: cert-manager
   disabled: false
   optionValues:
-    - name: cert-manager.config.gatewayAPI.enabled
-      value: {{ .Values.certManager.config.gatewayAPI.enabled }}
+    - name: cert-manager.cert-manager.extraArgs[1]
+      value: --enable-gateway-api
     - name: cert-manager.webhook.timeoutSeconds
       value: {{ .Values.certManager.webhook.timeoutSeconds }}
 {{ if .Values.digicertIssuer.enabled }}

--- a/system/greenhouse-organization/templates/plugins/external-dns.yaml
+++ b/system/greenhouse-organization/templates/plugins/external-dns.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.externalDns.enabled }}
+apiVersion: greenhouse.sap/v1alpha1
+kind: Plugin
+metadata:
+  name: external-dns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    "greenhouse.sap/owned-by": {{ .Values.externalDns.supportGroup | default .Values.global.supportGroup }}
+spec:
+  pluginDefinitionRef:
+    kind: PluginDefinition
+    name: external-dns
+  displayName: external-dns
+  releaseName: external-dns
+  releaseNamespace: external-dns
+  optionValues:
+    - name: openstack.enabled
+      value: {{ .Values.externalDns.openstack.enabled | default false }}
+    {{- if .Values.externalDns.openstack.enabled }}
+    - name: openstack.authURL
+      value: {{ required ".Values.externalDns.openstack.authURL missing" .Values.externalDns.openstack.authURL }}
+    - name: openstack.username
+      value: {{ required ".Values.externalDns.openstack.username missing" .Values.externalDns.openstack.username }}
+    - name: openstack.password
+      value: {{ required ".Values.externalDns.openstack.password missing" .Values.externalDns.openstack.password | quote }}
+    - name: openstack.userDomainName
+      value: {{ .Values.externalDns.openstack.userDomainName | default "Default" }}
+    - name: openstack.projectID
+      value: {{ required ".Values.externalDns.openstack.projectID missing" .Values.externalDns.openstack.projectID }}
+    - name: openstack.regionName
+      value: {{ required ".Values.externalDns.openstack.regionName missing" .Values.externalDns.openstack.regionName }}
+    {{- end }}
+    {{- with .Values.externalDns.options }}
+    {{- include "flattenOptionValues" (dict "prefix" "externaldns" "values" .) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/system/greenhouse-organization/templates/plugins/k8s-gateway-api.yaml
+++ b/system/greenhouse-organization/templates/plugins/k8s-gateway-api.yaml
@@ -1,0 +1,21 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.k8sGatewayApi.enabled }}
+apiVersion: greenhouse.sap/v1alpha1
+kind: Plugin
+metadata:
+  name: k8s-gateway-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    "greenhouse.sap/owned-by": {{ .Values.k8sGatewayApi.supportGroup | default .Values.global.supportGroup }}
+spec:
+  pluginDefinitionRef:
+    kind: PluginDefinition
+    name: k8s-gateway-api
+  displayName: k8s-gateway-api
+  releaseName: k8s-gateway-api
+  releaseNamespace: greenhouse
+{{- end }}

--- a/system/greenhouse-organization/templates/plugins/kgateway-crds.yaml
+++ b/system/greenhouse-organization/templates/plugins/kgateway-crds.yaml
@@ -1,0 +1,21 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.kgatewayCrds.enabled }}
+apiVersion: greenhouse.sap/v1alpha1
+kind: Plugin
+metadata:
+  name: kgateway-crds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    "greenhouse.sap/owned-by": {{ .Values.kgatewayCrds.supportGroup | default .Values.global.supportGroup }}
+spec:
+  pluginDefinitionRef:
+    kind: PluginDefinition
+    name: kgateway-crds
+  displayName: kgateway-crds
+  releaseName: kgateway-crds
+  releaseNamespace: kgateway-system
+{{- end }}

--- a/system/greenhouse-organization/templates/plugins/kgateway.yaml
+++ b/system/greenhouse-organization/templates/plugins/kgateway.yaml
@@ -1,0 +1,31 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.kgateway.enabled }}
+apiVersion: greenhouse.sap/v1alpha1
+kind: Plugin
+metadata:
+  name: kgateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    "greenhouse.sap/owned-by": {{ .Values.kgateway.supportGroup | default .Values.global.supportGroup }}
+spec:
+  pluginDefinitionRef:
+    kind: PluginDefinition
+    name: kgateway
+  displayName: kgateway
+  releaseName: kgateway
+  releaseNamespace: kgateway-system
+  optionValues:
+    - name: controller.replicaCount
+      value: {{ .Values.kgateway.controller.replicaCount | default 1 }}
+    - name: controller.serviceMonitor.enabled
+      value: {{ .Values.kgateway.controller.serviceMonitor.enabled | default false }}
+    {{- if .Values.kgateway.controller.serviceMonitor.enabled }}
+    - name: controller.serviceMonitor.extraLabels
+      value:
+        {{- toYaml (.Values.kgateway.controller.serviceMonitor.extraLabels | default (dict "plugin" "kube-monitoring")) | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/system/greenhouse-organization/values.yaml
+++ b/system/greenhouse-organization/values.yaml
@@ -84,6 +84,7 @@ catalogs:
           - shoot-grafter/plugindefinition.yaml
           - permission-manager/plugindefinition.yaml
           - gatekeeper/plugindefinition.yaml
+          - external-dns/plugindefinition.yaml
           - k8s-gateway-api/plugindefinition.yaml
           - kgateway-crds/plugindefinition.yaml
           - kgateway/plugindefinition.yaml
@@ -112,12 +113,14 @@ catalogs:
             repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/permission-manager/charts
           - name: gatekeeper
             repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
+          - name: external-dns
+            repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
           - name: k8s-gateway-api
             repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
           - name: kgateway-crds
-            repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
+            repository: oci://keppel.eu-de-1.cloud.sap/ccloud-kgateway-mirror/kgateway-dev/charts
           - name: kgateway
-            repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
+            repository: oci://keppel.eu-de-1.cloud.sap/ccloud-kgateway-mirror/kgateway-dev/charts
       - repository: https://github.wdf.sap.corp/sap-cloud-infrastructure/greenhouse-extensions
         ref:
           branch: main # using main for QA and playground, can be changed to a specific tag or commit for production
@@ -176,6 +179,19 @@ disco:
   password:
   projectName:
   projectDomainName:
+
+# Configures the external-dns for the Greenhouse organization, which enables automated management of DNS records with various DNS providers.
+externalDns:
+  enabled: false
+  openstack:
+    enabled: false
+    authURL:
+    username:
+    password:
+    userDomainName:
+    projectID:
+    regionName:
+  options: {}
 
 # Configures the NGINX ingress for the Greenhouse organization, which enables external access.
 ingress:

--- a/system/greenhouse-organization/values.yaml
+++ b/system/greenhouse-organization/values.yaml
@@ -84,6 +84,9 @@ catalogs:
           - shoot-grafter/plugindefinition.yaml
           - permission-manager/plugindefinition.yaml
           - gatekeeper/plugindefinition.yaml
+          - k8s-gateway-api/plugindefinition.yaml
+          - kgateway-crds/plugindefinition.yaml
+          - kgateway/plugindefinition.yaml
         overrides:
           - name: exposed-services
             repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
@@ -108,6 +111,12 @@ catalogs:
           - name: permission-manager
             repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/permission-manager/charts
           - name: gatekeeper
+            repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
+          - name: k8s-gateway-api
+            repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
+          - name: kgateway-crds
+            repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
+          - name: kgateway
             repository: oci://keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror/cloudoperators/greenhouse-extensions/charts
       - repository: https://github.wdf.sap.corp/sap-cloud-infrastructure/greenhouse-extensions
         ref:
@@ -144,9 +153,6 @@ teams:
 certManager:
   webhook:
     timeoutSeconds: 15
-  config:
-    gatewayAPI:
-      enabled: true
 
 # Configures the DigiCert issuer for the Greenhouse organization,
 # which enables obtaining DigiCert certificates via the cert-manager.
@@ -277,4 +283,17 @@ permissionmanager:
   enabled: false
 
 gatekeeper:
+  enabled: false
+
+k8sGatewayApi:
+  enabled: false
+
+kgateway:
+  enabled: false
+  controller:
+    replicaCount: 1
+    serviceMonitor:
+      enabled: false
+
+kgatewayCrds:
   enabled: false


### PR DESCRIPTION
Brings in external-dns, k8s gateway api crds and kgateway + crds into greenhouse organization