### PR TITLE
[cc-shoots-compute] Add support for in-place update strategy for workers

### DIFF
--- a/system/cc-shoots-compute/Chart.yaml
+++ b/system/cc-shoots-compute/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-compute
 description: Converged Cloud Gardener shoots
 type: application
-version: 2.6.9
+version: 2.7.0
 appVersion: "0.1.0"

--- a/system/cc-shoots-compute/templates/kvm-shoot.yaml
+++ b/system/cc-shoots-compute/templates/kvm-shoot.yaml
@@ -166,6 +166,7 @@ spec:
     workers:
     {{- range $workerkey, $worker := $cluster.workers }}
       {{- $workerChannel := coalesce $worker.channel $cluster.channel "release" }}
+      {{- $updateStrategy := coalesce $worker.updateStrategy $cluster.updateStrategy $.Values.defaultUpdateStrategy }}
       {{- $imageVersion:= "unset" }}
       {{- if eq $workerChannel "preRelease" }}
       {{- $imageVersion = coalesce $worker.preReleaseImageVersion $cluster.preReleaseImageVersion $.Values.preReleaseImageVersion }}
@@ -183,20 +184,23 @@ spec:
           type: baremetal
         minimum: {{ $worker.poolSize }}
         maximum: {{ $worker.poolSize }}
+        {{- if not (has $updateStrategy (list "ManualInPlaceUpdate" "AutoInPlaceUpdate")) }}
         maxSurge: {{ $worker.maxSurge | default 0 }}
         maxUnavailable: {{ default 1 $worker.maxUnavailable }}
-        {{- if $worker.updateStrategy }}
-        updateStrategy: {{ $worker.updateStrategy }}
         {{- end }}
+        updateStrategy: {{ $updateStrategy }}
         zones:
         {{- toYaml $worker.zones | nindent 8 }}
         machineControllerManager:
+        {{- if eq $updateStrategy "AutoRollingUpdate" }}
           machineCreationTimeout: {{ coalesce $worker.machineCreationTimeout $cluster.machineCreationTimeout "1h20m0s" }}
           machineHealthTimeout: {{ coalesce $worker.machineHealthTimeout $cluster.machineHealthTimeout "1h0m0s" }}
           machineDrainTimeout: {{ coalesce $worker.machineDrainTimeout $cluster.machineDrainTimeout "240h0m0s" }}
-          {{- if $worker.inPlaceUpdateTimeout }}
-          inPlaceUpdateTimeout: {{ $worker.inPlaceUpdateTimeout }}
-          {{- end }}
+        {{- else if has $updateStrategy (list "ManualInPlaceUpdate" "AutoInPlaceUpdate") }}
+          inPlaceUpdateTimeout: {{coalesce $worker.inPlaceUpdateTimeout $cluster.inPlaceUpdateTimeout "1h20m0s" }}
+        {{- else }}
+          {{- fail (printf "worker %s has invalid updateStrategy '%s': must be either 'AutoRollingUpdate', 'ManualInPlaceUpdate' or 'AutoInPlaceUpdate'" $workerkey $updateStrategy) }}
+        {{- end }}
         sysctls:
           vm.hugetlb_shm_group: "64055"
           vm.unprivileged_userfaultfd: "1"

--- a/system/cc-shoots-compute/values.yaml
+++ b/system/cc-shoots-compute/values.yaml
@@ -1,3 +1,4 @@
+defaultUpdateStrategy: AutoRollingUpdate
 authenticationConfig: {}
 kvmShoot: false
 networking:


### PR DESCRIPTION
Add support for in-place update strategy per worker. The default remains
`AutoRollingUpdate`. For `ManualInPlaceUpdate` and `AutoInPlaceUpdate`,
the `inPlaceUpdateTimeout` can be set per worker or cluster.
